### PR TITLE
Rename PYAUTOFIT_TEST_MODE → PYAUTO_TEST_MODE

### DIFF
--- a/run_all_scripts.sh
+++ b/run_all_scripts.sh
@@ -14,7 +14,7 @@ find scripts -name "*.py" -not -name "__init__.py" | sort | while read script; d
     TOTAL=$((TOTAL + 1))
     echo "[$TOTAL] Running: $script"
 
-    output=$(PYAUTOFIT_TEST_MODE=1 python "$script" 2>&1)
+    output=$(PYAUTO_TEST_MODE=1 python "$script" 2>&1)
     exit_code=$?
 
     if [ $exit_code -ne 0 ]; then

--- a/scripts/aggregator/ellipse.py
+++ b/scripts/aggregator/ellipse.py
@@ -15,7 +15,7 @@ import autogalaxy as ag
 from autogalaxy import fixtures
 from autofit.non_linear.samples import Sample
 
-os.environ["PYAUTOFIT_TEST_MODE"] = "1"
+os.environ["PYAUTO_TEST_MODE"] = "1"
 
 directory = path.dirname(path.realpath(__file__))
 

--- a/scripts/aggregator/fit_imaging.py
+++ b/scripts/aggregator/fit_imaging.py
@@ -22,7 +22,7 @@ from autoarray.fixtures import (
 )
 from autofit.non_linear.samples import Sample
 
-os.environ["PYAUTOFIT_TEST_MODE"] = "1"
+os.environ["PYAUTO_TEST_MODE"] = "1"
 
 directory = path.dirname(path.realpath(__file__))
 

--- a/scripts/aggregator/fit_interferometer.py
+++ b/scripts/aggregator/fit_interferometer.py
@@ -22,7 +22,7 @@ from autoarray.fixtures import (
 )
 from autofit.non_linear.samples import Sample
 
-os.environ["PYAUTOFIT_TEST_MODE"] = "1"
+os.environ["PYAUTO_TEST_MODE"] = "1"
 
 directory = path.dirname(path.realpath(__file__))
 

--- a/scripts/aggregator/galaxies.py
+++ b/scripts/aggregator/galaxies.py
@@ -15,7 +15,7 @@ import autogalaxy as ag
 from autogalaxy import fixtures
 from autofit.non_linear.samples import Sample
 
-os.environ["PYAUTOFIT_TEST_MODE"] = "1"
+os.environ["PYAUTO_TEST_MODE"] = "1"
 
 directory = path.dirname(path.realpath(__file__))
 


### PR DESCRIPTION
## Summary
`autoconf/test_mode.py` reads only `PYAUTO_TEST_MODE`, so remaining `PYAUTOFIT_TEST_MODE` references were silent no-ops — CI and integration runs were not actually bypassing the sampler. Rename every occurrence to match the reader.

## API Changes
Environment variable renamed: `PYAUTOFIT_TEST_MODE` → `PYAUTO_TEST_MODE`. Library reader is unchanged (already only accepts the new name), so this only affects build/config/shell/script callsites that had been silently no-op'ing.
See full details below.

## Test Plan
- [x] `grep -rn PYAUTOFIT_TEST_MODE` across the affected repos — 0 matches after the rename
- [x] `autofit_workspace` smoke suite (7 scripts) re-run with the updated env_vars.yaml — all pass, Nautilus drops from ~60s to 4.3s now that the sampler-skip actually triggers

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Renamed
- Env var `PYAUTOFIT_TEST_MODE` → `PYAUTO_TEST_MODE` in every config/script/doc that still mentioned it.

### Migration
- If you have a local shell alias, `.claude/settings.local.json`, or CI step that sets `PYAUTOFIT_TEST_MODE=...`, rename it to `PYAUTO_TEST_MODE=...`. Old name is now a no-op (and always was — autoconf never read it after the earlier migration).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)