### PR TITLE
Remove PySwarms and UltraNest references

### DIFF
--- a/config/non_linear/README.rst
+++ b/config/non_linear/README.rst
@@ -6,4 +6,4 @@ Files
 
 - ``mcmc.yaml``: Settings default behaviour of MCMC non-linear searches (e.g. Emcee).
 - ``nest.yaml``: Settings default behaviour of nested sampler non-linear searches (e.g. Dynesty).
-- ``mle.yaml``: Settings default behaviour of maximum likelihood estimator (mle) searches (e.g. PySwarms).
+- ``mle.yaml``: Settings default behaviour of maximum likelihood estimator (mle) searches (e.g. LBFGS).


### PR DESCRIPTION
## Summary
- Remove PySwarms and UltraNest references — these searches are no longer supported in PyAutoFit
- Strip scripts, notebooks, READMEs, config entries, tutorial prose, and citation lines that pointed users at broken examples
- The developer workspace is untouched (it intentionally preserves the legacy implementations)

## Test plan
- [ ] Grep sweep returns 0 hits for `pyswarm|ultranest` outside generated logs and `autofit_workspace_developer`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)