### PR TITLE
ci: set up GitHub Actions smoke test workflow

### DIFF
--- a/.github/scripts/run_smoke.py
+++ b/.github/scripts/run_smoke.py
@@ -1,0 +1,112 @@
+"""
+Run the workspace smoke test suite.
+
+Reads `smoke_tests.txt` from the workspace root and `config/build/env_vars.yaml`
+for per-script env var overrides, then runs each listed script with the
+appropriate environment. Continues through failures and exits non-zero
+if any script failed.
+
+Mirrors the logic of the `/smoke-test` skill so CI and local runs stay
+in sync.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import yaml
+
+
+WORKSPACE = Path(__file__).resolve().parents[2]
+SMOKE_FILE = WORKSPACE / "smoke_tests.txt"
+ENV_VARS_FILE = WORKSPACE / "config" / "build" / "env_vars.yaml"
+SCRIPTS_DIR = WORKSPACE / "scripts"
+
+
+def load_smoke_scripts() -> list[str]:
+    scripts: list[str] = []
+    for line in SMOKE_FILE.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        scripts.append(line)
+    return scripts
+
+
+def load_env_config() -> dict:
+    if not ENV_VARS_FILE.exists():
+        return {"defaults": {}, "overrides": []}
+    return yaml.safe_load(ENV_VARS_FILE.read_text()) or {}
+
+
+def pattern_matches(pattern: str, script_path: str) -> bool:
+    if "/" in pattern:
+        return pattern in script_path
+    return Path(script_path).stem == pattern
+
+
+def build_env(script_rel: str, cfg: dict) -> dict:
+    env = os.environ.copy()
+    defaults = cfg.get("defaults") or {}
+    env.update({k: str(v) for k, v in defaults.items()})
+    for override in cfg.get("overrides") or []:
+        if pattern_matches(override["pattern"], script_rel):
+            for key in override.get("unset", []):
+                env.pop(key, None)
+            for key, val in (override.get("set") or {}).items():
+                env[key] = str(val)
+    return env
+
+
+def run_one(script_rel: str, cfg: dict) -> tuple[str, int, float, str]:
+    env = build_env(script_rel, cfg)
+    script_path = SCRIPTS_DIR / script_rel
+    t0 = time.time()
+    result = subprocess.run(
+        [sys.executable, str(script_path)],
+        cwd=str(WORKSPACE),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    elapsed = time.time() - t0
+    output = result.stdout + result.stderr
+    return script_rel, result.returncode, elapsed, output
+
+
+def main() -> int:
+    if not SMOKE_FILE.exists():
+        print(f"ERROR: no smoke_tests.txt at {SMOKE_FILE}", file=sys.stderr)
+        return 1
+    scripts = load_smoke_scripts()
+    if not scripts:
+        print("No smoke test scripts listed.")
+        return 0
+    cfg = load_env_config()
+
+    print(f"Running {len(scripts)} smoke test script(s) from {SMOKE_FILE.name}\n")
+    failures: list[tuple[str, int, str]] = []
+    for script_rel in scripts:
+        print(f"::group::{script_rel}")
+        name, rc, elapsed, output = run_one(script_rel, cfg)
+        print(output, end="")
+        status = "PASS" if rc == 0 else f"FAIL (exit {rc})"
+        print(f"\n[{status}] {name} — {elapsed:.1f}s")
+        print("::endgroup::")
+        if rc != 0:
+            failures.append((name, rc, output))
+
+    total = len(scripts)
+    passed = total - len(failures)
+    print(f"\n=== Smoke test summary: {passed}/{total} passed ===")
+    for name, rc, _ in failures:
+        print(f"  FAIL  {name}  (exit {rc})")
+    return 0 if not failures else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -1,0 +1,95 @@
+name: Smoke Tests
+
+on: [push, pull_request]
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.12', '3.13']
+    steps:
+    - name: Checkout PyAutoConf
+      uses: actions/checkout@v4
+      with:
+        repository: PyAutoLabs/PyAutoConf
+        path: PyAutoConf
+    - name: Checkout PyAutoFit
+      uses: actions/checkout@v4
+      with:
+        repository: PyAutoLabs/PyAutoFit
+        path: PyAutoFit
+    - name: Checkout PyAutoArray
+      uses: actions/checkout@v4
+      with:
+        repository: PyAutoLabs/PyAutoArray
+        path: PyAutoArray
+    - name: Checkout PyAutoGalaxy
+      uses: actions/checkout@v4
+      with:
+        repository: PyAutoLabs/PyAutoGalaxy
+        path: PyAutoGalaxy
+    - name: Checkout workspace
+      uses: actions/checkout@v4
+      with:
+        path: workspace
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Extract branch name
+      id: extract_branch
+      shell: bash
+      run: |
+        cd workspace
+        echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> "$GITHUB_OUTPUT"
+    - name: Match library branches
+      shell: bash
+      run: |
+        BRANCH="${{ steps.extract_branch.outputs.branch }}"
+        for PKG in PyAutoConf PyAutoFit PyAutoArray PyAutoGalaxy; do
+          pushd "$PKG"
+          if [[ -n "$(git ls-remote --heads origin "$BRANCH")" ]]; then
+            echo "Branch $BRANCH exists in $PKG — checking out"
+            git fetch origin "$BRANCH"
+            git checkout "$BRANCH"
+          else
+            echo "Branch $BRANCH not in $PKG — staying on main"
+          fi
+          popd
+        done
+    - name: Install dependencies
+      run: |
+        pip install --upgrade pip setuptools wheel
+        pip install pyyaml
+        if [ "${{ matrix.python-version }}" = "3.12" ]; then
+          pip install ./PyAutoConf ./PyAutoFit ./PyAutoArray ./PyAutoGalaxy
+          pip install "./PyAutoArray[optional]" "./PyAutoGalaxy[optional]"
+        else
+          pip install ./PyAutoConf ./PyAutoFit ./PyAutoArray ./PyAutoGalaxy
+          pip install numba
+        fi
+        pip install tensorflow-probability==0.25.0
+    - name: Prepare cache dirs
+      run: |
+        mkdir -p /tmp/numba_cache /tmp/matplotlib
+    - name: Run smoke tests
+      env:
+        JAX_ENABLE_X64: "True"
+        NUMBA_CACHE_DIR: /tmp/numba_cache
+        MPLCONFIGDIR: /tmp/matplotlib
+      run: |
+        cd workspace
+        python .github/scripts/run_smoke.py
+    - name: Slack notify on failure
+      if: ${{ failure() }}
+      uses: slackapi/slack-github-action@v1.21.0
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      with:
+        channel-id: C03S98FEDK2
+        payload: |
+          {
+            "text": "${{ github.repository }}/${{ github.ref_name }} smoke tests (Python ${{ matrix.python-version }}) ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          }

--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -1,0 +1,23 @@
+# Per-script environment variable configuration for automated runs
+# (smoke tests, pre-release checks, CI).
+#
+# "defaults" are applied to every script on top of the inherited environment.
+# "overrides" selectively unset or replace vars for matching path patterns.
+#
+# Pattern convention (same as no_run.yaml):
+#   - Patterns containing '/' do a substring match against the file path
+#   - Patterns without '/' match the file stem exactly
+
+defaults:
+  PYAUTOFIT_TEST_MODE: "2"              # 0=normal, 1=reduced iterations, 2=skip sampler (fastest)
+  PYAUTO_WORKSPACE_SMALL_DATASETS: "1"  # Cap grids/masks to 15x15, reduce MGE gaussians
+  PYAUTO_DISABLE_JAX: "1"              # Force use_jax=False, avoid JIT compilation overhead
+  PYAUTO_FAST_PLOTS: "1"               # Skip tight_layout() + critical curve/caustic overlays
+  JAX_ENABLE_X64: "True"               # Enable 64-bit precision in JAX
+  NUMBA_CACHE_DIR: "/tmp/numba_cache"   # Writable cache dir for numba
+  MPLCONFIGDIR: "/tmp/matplotlib"       # Writable config dir for matplotlib
+
+overrides:
+  # JAX likelihood functions test JIT compilation — need JAX enabled and full-size datasets
+  - pattern: "jax_likelihood_functions/"
+    unset: [PYAUTO_WORKSPACE_SMALL_DATASETS, PYAUTO_DISABLE_JAX]


### PR DESCRIPTION
## Summary

autogalaxy_workspace_test has no CI today. This PR adds a GitHub Actions smoke-test workflow mirroring autolens_workspace_test's setup (minus PyAutoLens), plus the supporting `run_smoke.py` runner and `config/build/env_vars.yaml` env-override config.

This is the blocker for the remaining eight sub-tasks in umbrella epic #5 — once CI is green, each subsequent PR that appends scripts to `smoke_tests.txt` gets end-to-end verification on Python 3.12 and 3.13.

## Scripts Changed

No existing scripts changed. Three new CI-infrastructure files added:

- `.github/workflows/smoke_tests.yml` — forked from autolens_workspace_test. PyAutoLens checkout + install step stripped; everything else (Python 3.12/3.13 matrix, branch-matching for PyAutoConf/Fit/Array/Galaxy, tensorflow-probability pin, numba install on 3.13, Slack-on-failure webhook) kept verbatim.
- `.github/scripts/run_smoke.py` — verbatim copy from autolens_workspace_test. Workspace-agnostic runner; reads `smoke_tests.txt` + `config/build/env_vars.yaml` relative to workspace root.
- `config/build/env_vars.yaml` — defaults match autolens (`PYAUTOFIT_TEST_MODE=2`, `PYAUTO_WORKSPACE_SMALL_DATASETS=1`, `PYAUTO_DISABLE_JAX=1`, `PYAUTO_FAST_PLOTS=1`, `JAX_ENABLE_X64`, cache dirs). One override: `jax_likelihood_functions/` unsets the small-dataset + disable-JAX flags. The autolens `database/scrape/`, `imaging/*`, `jax_grad/*`, and `interferometer/visualization` overrides are omitted — none of those paths exist in autogalaxy_workspace_test yet; sibling PRs will add overrides alongside their scripts.

`smoke_tests.txt` unchanged — already lists the 4 aggregator scripts, which form the initial suite.

## Test Plan

- [ ] Local smoke test passes (`python .github/scripts/run_smoke.py` from the worktree with `activate.sh` sourced)
- [ ] GitHub Actions workflow runs green on Python 3.12
- [ ] GitHub Actions workflow runs green on Python 3.13

Closes #6
Part of #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)