### PR TITLE
docs: update stale admin_jammy/prompt/ refs to PyAutoPrompt/

### DIFF
--- a/smoke_tests.txt
+++ b/smoke_tests.txt
@@ -8,6 +8,6 @@ jax_likelihood_functions/imaging/mge_group.py
 jax_likelihood_functions/imaging/rectangular.py
 jax_likelihood_functions/imaging/rectangular_mge.py
 jax_likelihood_functions/imaging/delaunay.py
-# jax_likelihood_functions/imaging/delaunay_mge.py  # disabled: jax 0.7 removed jax.interpreters.xla.pytype_aval_mappings — see admin_jammy/prompt/build/smoke_workspace_fixes.md
+# jax_likelihood_functions/imaging/delaunay_mge.py  # disabled: jax 0.7 removed jax.interpreters.xla.pytype_aval_mappings — see PyAutoPrompt/autobuild/smoke_workspace_fixes.md
 imaging/model_fit.py
 imaging/visualization.py


### PR DESCRIPTION
## Summary

The PyAuto prompt registry was moved from `admin_jammy/prompt/` to `PyAutoPrompt/` on 2026-04-27. This PR updates stale comment / docstring / YAML / Markdown references in this repo to point at the new location.

## Files Changed

- `smoke_tests.txt` — comment ref to the smoke-workspace-fixes prompt updated

## Test Plan

- [x] Pure text-substitution edits — comments, docstrings, YAML comments, Markdown text only
- [x] Zero runtime behavior change; no executable code paths modified
- [N/A] Smoke tests skipped — not justified for comment-only edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)