### PR TITLE
docs: add Never-rewrite-history guard to CLAUDE.md / AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,3 +56,26 @@ Tests use `MockSearch` + `MockSamples` to create mock model-fit results, scrape 
 ## Line Endings — Always Unix (LF)
 
 All files **must use Unix line endings (LF, `\n`)**. Never write `\r\n` line endings.
+## Never rewrite history
+
+NEVER perform these operations on any repo with a remote:
+
+- `git init` in a directory already tracked by git
+- `rm -rf .git && git init`
+- Commit with subject "Initial commit", "Fresh start", "Start fresh", "Reset
+  for AI workflow", or any equivalent message on a branch with a remote
+- `git push --force` to `main` (or any branch tracked as `origin/HEAD`)
+- `git filter-repo` / `git filter-branch` on shared branches
+- `git rebase -i` rewriting commits already pushed to a shared branch
+
+If the working tree needs a clean state, the **only** correct sequence is:
+
+    git fetch origin
+    git reset --hard origin/main
+    git clean -fd
+
+This applies equally to humans, local Claude Code, cloud Claude agents, Codex,
+and any other agent. The "Initial commit — fresh start for AI workflow" pattern
+that appeared independently on origin and local for three workspace repos is
+exactly what this rule prevents — it costs ~40 commits of redundant local work
+every time it happens.


### PR DESCRIPTION
## Summary
Append a `## Never rewrite history` section to this repo's `CLAUDE.md` and/or `AGENTS.md` (whichever exist) listing destructive history operations that should never run on a remote-tracked branch, with the canonical clean-working-tree sequence as the only correct alternative.

One of 17 PRs implementing PyAutoLabs/PyAutoPrompt#7 (history-rewrite-guard umbrella).

## Test Plan
- [ ] `grep "## Never rewrite history" CLAUDE.md AGENTS.md` returns the section.
- [ ] Existing content of these files is unchanged above the new section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)