### PR TITLE
feat: jax_likelihood_functions/multi/ port

### DIFF
--- a/scripts/jax_likelihood_functions/multi/delaunay.py
+++ b/scripts/jax_likelihood_functions/multi/delaunay.py
@@ -1,0 +1,259 @@
+"""
+JAX Likelihood: Delaunay Adapt-Image Pixelization (Multi-Wavelength)
+=====================================================================
+
+Verify that JAX can compute the log-likelihood of a multi-wavelength
+``Imaging`` fit for an autogalaxy model using a ``Delaunay`` mesh with a
+Hilbert image-mesh (which seeds source-pixel centres in the image plane via
+an adapt image) and ``AdaptSplit`` regularization.
+Two paths are exercised:
+
+1. ``fitness._vmap`` batch evaluation over a ``af.FactorGraphModel`` that
+   combines per-band ``AnalysisImaging`` factors.
+2. ``jax.jit`` over a parameter-vector entry point:
+   ``instance_from_vector`` → ``factor_graph.log_likelihood_function``.
+
+Uses **option B** — per-band ``galaxy.pixelization.regularization.inner_coefficient``
+priors via ``model.copy()`` + ``af.GaussianPrior`` on each ``AnalysisFactor``.
+The mesh parameters and outer regularization params stay shared.
+
+Path A asserts JIT round-trip parity with the vmap result (pixelized path
+differs between use_jax=True and use_jax=False).
+"""
+
+from os import path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import autofit as af
+import autogalaxy as ag
+
+
+waveband_list = ["g", "r"]
+pixel_scales = 0.1
+mask_radius = 3.0
+
+dataset_path = path.join("dataset", "multi", "jax_test")
+
+if not path.exists(path.join(dataset_path, "g_data.fits")):
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/jax_likelihood_functions/multi/simulator.py"],
+        check=True,
+    )
+
+dataset_list = [
+    ag.Imaging.from_fits(
+        data_path=path.join(dataset_path, f"{band}_data.fits"),
+        psf_path=path.join(dataset_path, f"{band}_psf.fits"),
+        noise_map_path=path.join(dataset_path, f"{band}_noise_map.fits"),
+        pixel_scales=pixel_scales,
+    )
+    for band in waveband_list
+]
+
+mask_list = [
+    ag.Mask2D.circular(
+        shape_native=dataset.shape_native,
+        pixel_scales=dataset.pixel_scales,
+        radius=mask_radius,
+    )
+    for dataset in dataset_list
+]
+
+dataset_list = [
+    dataset.apply_mask(mask=mask) for dataset, mask in zip(dataset_list, mask_list)
+]
+dataset_list = [
+    dataset.apply_over_sampling(
+        over_sample_size_lp=1, over_sample_size_pixelization=1
+    )
+    for dataset in dataset_list
+]
+
+"""
+__Image-Plane Mesh & Adapt Images (per band)__
+
+JAX requires static-shaped arrays. ``pixels`` and ``edge_pixels_total`` fix the
+total source-pixel count up front. The image-plane mesh grid is built in
+NumPy via the Hilbert image-mesh and circle-edge augmentation, then passed
+in via ``galaxy_name_image_plane_mesh_grid_dict``.
+"""
+pixels = 500
+edge_pixels_total = 30
+
+adapt_images_list = []
+for dataset, mask in zip(dataset_list, mask_list):
+    galaxy_name_image_dict = {
+        "('galaxies', 'galaxy')": dataset.data,
+    }
+    image_mesh = ag.image_mesh.Hilbert(
+        pixels=pixels, weight_power=3.5, weight_floor=0.01
+    )
+    image_plane_mesh_grid = image_mesh.image_plane_mesh_grid_from(
+        mask=dataset.mask, adapt_data=galaxy_name_image_dict["('galaxies', 'galaxy')"]
+    )
+    image_plane_mesh_grid = ag.image_mesh.append_with_circle_edge_points(
+        image_plane_mesh_grid=image_plane_mesh_grid,
+        centre=mask.mask_centre,
+        radius=mask_radius + mask.pixel_scale / 2.0,
+        n_points=edge_pixels_total,
+    )
+    adapt_images_list.append(
+        ag.AdaptImages(
+            galaxy_name_image_dict=galaxy_name_image_dict,
+            galaxy_name_image_plane_mesh_grid_dict={
+                "('galaxies', 'galaxy')": image_plane_mesh_grid
+            },
+        )
+    )
+
+"""
+__Model__
+
+Single galaxy with a Delaunay pixelization seeded by the Hilbert image-mesh.
+"""
+pixelization = af.Model(
+    ag.Pixelization,
+    mesh=ag.mesh.Delaunay(pixels=pixels, zeroed_pixels=edge_pixels_total),
+    regularization=ag.reg.AdaptSplit,
+)
+
+galaxy = af.Model(ag.Galaxy, redshift=0.5, pixelization=pixelization)
+model = af.Collection(galaxies=af.Collection(galaxy=galaxy))
+
+print(model.info)
+
+"""
+__Per-band models (option B)__
+
+Each band gets its own ``model.copy()`` with an independent prior on the
+regularization ``inner_coefficient``.
+"""
+model_per_band_list = []
+for _ in waveband_list:
+    model_analysis = model.copy()
+    model_analysis.galaxies.galaxy.pixelization.regularization.inner_coefficient = (
+        af.GaussianPrior(mean=1.0, sigma=0.5)
+    )
+    model_per_band_list.append(model_analysis)
+
+"""
+__FactorGraphModel (vmap path)__
+"""
+settings = ag.Settings(use_border_relocator=True)
+
+analysis_list = [
+    ag.AnalysisImaging(
+        dataset=dataset,
+        adapt_images=adapt_images,
+        settings=settings,
+    )
+    for dataset, adapt_images in zip(dataset_list, adapt_images_list)
+]
+
+analysis_factor_list = [
+    af.AnalysisFactor(prior_model=m, analysis=analysis)
+    for m, analysis in zip(model_per_band_list, analysis_list)
+]
+
+factor_graph = af.FactorGraphModel(*analysis_factor_list, use_jax=True)
+
+print(factor_graph.global_prior_model.info)
+
+from autofit.non_linear.fitness import Fitness
+import time
+
+batch_size = 3
+
+fitness = Fitness(
+    model=factor_graph.global_prior_model,
+    analysis=factor_graph,
+    fom_is_log_likelihood=True,
+    resample_figure_of_merit=-1.0e99,
+)
+
+parameters = np.zeros(
+    (batch_size, factor_graph.global_prior_model.total_free_parameters)
+)
+for i in range(batch_size):
+    parameters[i, :] = (
+        factor_graph.global_prior_model.physical_values_from_prior_medians
+    )
+parameters = jnp.array(parameters)
+
+start = time.time()
+result = fitness._vmap(parameters)
+print(result)
+print("JAX Time To VMAP + JIT Function:", time.time() - start)
+
+start = time.time()
+result = fitness._vmap(parameters)
+print("JAX Time Taken using VMAP:", time.time() - start)
+print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
+
+
+"""
+__Path A: jit-wrap ``factor_graph.log_likelihood_function``__
+
+``FactorGraphModel`` has no ``fit_from`` method, so Path A jit-wraps a
+parameter-vector entry point that mirrors what ``fitness._vmap`` does
+internally: ``instance_from_vector`` → ``log_likelihood_function``.
+
+The adapt-regularization linear solve has ~1% NumPy/JAX float-ordering
+drift — same as the single-dataset autogalaxy ``imaging/delaunay.py``
+and ``interferometer/delaunay.py``, so the rtol=1e-2 convention applies.
+"""
+from autofit.jax.pytrees import enable_pytrees, register_model
+
+enable_pytrees()
+register_model(factor_graph.global_prior_model)
+
+analysis_np_list = [
+    ag.AnalysisImaging(
+        dataset=dataset,
+        adapt_images=adapt_images,
+        settings=settings,
+        use_jax=False,
+    )
+    for dataset, adapt_images in zip(dataset_list, adapt_images_list)
+]
+analysis_factor_np_list = [
+    af.AnalysisFactor(prior_model=m, analysis=a)
+    for m, a in zip(model_per_band_list, analysis_np_list)
+]
+factor_graph_np = af.FactorGraphModel(*analysis_factor_np_list, use_jax=False)
+
+params_np = np.array(
+    factor_graph_np.global_prior_model.physical_values_from_prior_medians
+)
+instance_np = factor_graph_np.global_prior_model.instance_from_vector(
+    vector=params_np, xp=np
+)
+log_l_np = float(factor_graph_np.log_likelihood_function(instance_np))
+print("NumPy log_likelihood_function:", log_l_np)
+
+
+@jax.jit
+def log_l_jit_fn(parameters):
+    instance = factor_graph.global_prior_model.instance_from_vector(
+        vector=parameters, xp=jnp
+    )
+    return factor_graph.log_likelihood_function(instance)
+
+
+params_jit = jnp.array(
+    factor_graph.global_prior_model.physical_values_from_prior_medians
+)
+log_l_jit = log_l_jit_fn(params_jit)
+
+print("JIT log_likelihood_function:", log_l_jit)
+assert isinstance(log_l_jit, jnp.ndarray), (
+    f"expected jax.Array, got {type(log_l_jit)}"
+)
+np.testing.assert_allclose(float(log_l_jit), log_l_np, rtol=1e-2)
+print("PASS: jit(log_likelihood_function) round-trip matches NumPy scalar.")

--- a/scripts/jax_likelihood_functions/multi/delaunay_mge.py
+++ b/scripts/jax_likelihood_functions/multi/delaunay_mge.py
@@ -1,0 +1,277 @@
+"""
+JAX Likelihood: Delaunay + MGE Bulge (Multi-Wavelength)
+========================================================
+
+Verify that JAX can compute the log-likelihood of a multi-wavelength
+``Imaging`` fit for an autogalaxy model with two galaxies:
+  - galaxy_0: MGE bulge (provides linear light profiles)
+  - galaxy_1: Delaunay pixelization with MaternAdaptKernel regularization
+               seeded by a Hilbert image-mesh
+
+Two paths are exercised:
+
+1. ``fitness._vmap`` batch evaluation over a ``af.FactorGraphModel`` that
+   combines per-band ``AnalysisImaging`` factors.
+2. ``jax.jit`` over a parameter-vector entry point:
+   ``instance_from_vector`` → ``factor_graph.log_likelihood_function``.
+
+Uses **option B** — per-band ``galaxy_1.pixelization.regularization.inner_coefficient``
+priors via ``model.copy()`` + ``af.GaussianPrior`` on each ``AnalysisFactor``.
+The MGE bulge parameters stay shared across bands.
+
+Path A asserts JIT round-trip parity with the vmap result (pixelized path
+differs between use_jax=True and use_jax=False).
+
+Note: If JAX 0.7's ``pytype_aval_mappings`` removal breaks this script,
+mark JAX_07_BROKEN and mirror imaging's commented-out treatment.
+"""
+
+from os import path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import autofit as af
+import autogalaxy as ag
+
+
+waveband_list = ["g", "r"]
+pixel_scales = 0.1
+mask_radius = 3.0
+
+dataset_path = path.join("dataset", "multi", "jax_test")
+
+if not path.exists(path.join(dataset_path, "g_data.fits")):
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/jax_likelihood_functions/multi/simulator.py"],
+        check=True,
+    )
+
+dataset_list = [
+    ag.Imaging.from_fits(
+        data_path=path.join(dataset_path, f"{band}_data.fits"),
+        psf_path=path.join(dataset_path, f"{band}_psf.fits"),
+        noise_map_path=path.join(dataset_path, f"{band}_noise_map.fits"),
+        pixel_scales=pixel_scales,
+    )
+    for band in waveband_list
+]
+
+mask_list = [
+    ag.Mask2D.circular(
+        shape_native=dataset.shape_native,
+        pixel_scales=dataset.pixel_scales,
+        radius=mask_radius,
+    )
+    for dataset in dataset_list
+]
+
+dataset_list = [
+    dataset.apply_mask(mask=mask) for dataset, mask in zip(dataset_list, mask_list)
+]
+dataset_list = [
+    dataset.apply_over_sampling(
+        over_sample_size_lp=1, over_sample_size_pixelization=1
+    )
+    for dataset in dataset_list
+]
+
+"""
+__Image-Plane Mesh & Adapt Images (per band)__
+
+JAX requires static-shaped arrays. ``pixels`` and ``edge_pixels_total`` fix the
+total source-pixel count up front. The image-plane mesh grid for ``galaxy_1``
+is built in NumPy via the Hilbert image-mesh.
+"""
+pixels = 500
+edge_pixels_total = 30
+
+adapt_images_list = []
+for dataset, mask in zip(dataset_list, mask_list):
+    galaxy_name_image_dict = {
+        "('galaxies', 'galaxy_0')": dataset.data,
+        "('galaxies', 'galaxy_1')": dataset.data,
+    }
+    image_mesh = ag.image_mesh.Hilbert(
+        pixels=pixels, weight_power=3.5, weight_floor=0.01
+    )
+    image_plane_mesh_grid = image_mesh.image_plane_mesh_grid_from(
+        mask=dataset.mask,
+        adapt_data=galaxy_name_image_dict["('galaxies', 'galaxy_1')"],
+    )
+    image_plane_mesh_grid = ag.image_mesh.append_with_circle_edge_points(
+        image_plane_mesh_grid=image_plane_mesh_grid,
+        centre=mask.mask_centre,
+        radius=mask_radius + mask.pixel_scale / 2.0,
+        n_points=edge_pixels_total,
+    )
+    adapt_images_list.append(
+        ag.AdaptImages(
+            galaxy_name_image_dict=galaxy_name_image_dict,
+            galaxy_name_image_plane_mesh_grid_dict={
+                "('galaxies', 'galaxy_1')": image_plane_mesh_grid
+            },
+        )
+    )
+
+"""
+__Model__
+
+galaxy_0: MGE bulge.
+galaxy_1: Delaunay pixelization with MaternAdaptKernel regularization.
+"""
+bulge = ag.model_util.mge_model_from(
+    mask_radius=mask_radius,
+    total_gaussians=10,
+    centre_prior_is_uniform=True,
+)
+
+galaxy_0 = af.Model(ag.Galaxy, redshift=0.5, bulge=bulge)
+
+pixelization = af.Model(
+    ag.Pixelization,
+    mesh=ag.mesh.Delaunay(pixels=pixels, zeroed_pixels=edge_pixels_total),
+    regularization=ag.reg.MaternAdaptKernel,
+)
+
+galaxy_1 = af.Model(ag.Galaxy, redshift=0.5, pixelization=pixelization)
+
+model = af.Collection(
+    galaxies=af.Collection(galaxy_0=galaxy_0, galaxy_1=galaxy_1)
+)
+
+print(model.info)
+
+"""
+__Per-band models (option B)__
+
+Each band gets its own ``model.copy()`` with an independent prior on the
+regularization ``inner_coefficient``.
+"""
+model_per_band_list = []
+for _ in waveband_list:
+    model_analysis = model.copy()
+    model_analysis.galaxies.galaxy_1.pixelization.regularization.inner_coefficient = (
+        af.GaussianPrior(mean=1.0, sigma=0.5)
+    )
+    model_per_band_list.append(model_analysis)
+
+"""
+__FactorGraphModel (vmap path)__
+"""
+settings = ag.Settings(use_border_relocator=True)
+
+analysis_list = [
+    ag.AnalysisImaging(
+        dataset=dataset,
+        adapt_images=adapt_images,
+        settings=settings,
+    )
+    for dataset, adapt_images in zip(dataset_list, adapt_images_list)
+]
+
+analysis_factor_list = [
+    af.AnalysisFactor(prior_model=m, analysis=analysis)
+    for m, analysis in zip(model_per_band_list, analysis_list)
+]
+
+factor_graph = af.FactorGraphModel(*analysis_factor_list, use_jax=True)
+
+print(factor_graph.global_prior_model.info)
+
+from autofit.non_linear.fitness import Fitness
+import time
+
+batch_size = 3
+
+fitness = Fitness(
+    model=factor_graph.global_prior_model,
+    analysis=factor_graph,
+    fom_is_log_likelihood=True,
+    resample_figure_of_merit=-1.0e99,
+)
+
+parameters = np.zeros(
+    (batch_size, factor_graph.global_prior_model.total_free_parameters)
+)
+for i in range(batch_size):
+    parameters[i, :] = (
+        factor_graph.global_prior_model.physical_values_from_prior_medians
+    )
+parameters = jnp.array(parameters)
+
+start = time.time()
+result = fitness._vmap(parameters)
+print(result)
+print("JAX Time To VMAP + JIT Function:", time.time() - start)
+
+start = time.time()
+result = fitness._vmap(parameters)
+print("JAX Time Taken using VMAP:", time.time() - start)
+print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
+
+
+"""
+__Path A: jit-wrap ``factor_graph.log_likelihood_function``__
+
+``FactorGraphModel`` has no ``fit_from`` method, so Path A jit-wraps a
+parameter-vector entry point that mirrors what ``fitness._vmap`` does
+internally: ``instance_from_vector`` → ``log_likelihood_function``.
+
+The adapt-regularization linear solve has ~1% NumPy/JAX float-ordering
+drift — same as the single-dataset autogalaxy ``imaging/delaunay_mge.py``
+and ``interferometer/delaunay_mge.py``, so the rtol=1e-2 convention applies.
+"""
+from autofit.jax.pytrees import enable_pytrees, register_model
+
+enable_pytrees()
+register_model(factor_graph.global_prior_model)
+
+analysis_np_list = [
+    ag.AnalysisImaging(
+        dataset=dataset,
+        adapt_images=adapt_images,
+        settings=settings,
+        use_jax=False,
+    )
+    for dataset, adapt_images in zip(dataset_list, adapt_images_list)
+]
+analysis_factor_np_list = [
+    af.AnalysisFactor(prior_model=m, analysis=a)
+    for m, a in zip(model_per_band_list, analysis_np_list)
+]
+factor_graph_np = af.FactorGraphModel(*analysis_factor_np_list, use_jax=False)
+
+params_np = np.array(
+    factor_graph_np.global_prior_model.physical_values_from_prior_medians
+)
+instance_np = factor_graph_np.global_prior_model.instance_from_vector(
+    vector=params_np, xp=np
+)
+log_l_np = float(factor_graph_np.log_likelihood_function(instance_np))
+print("NumPy log_likelihood_function:", log_l_np)
+
+
+@jax.jit
+def log_l_jit_fn(parameters):
+    instance = factor_graph.global_prior_model.instance_from_vector(
+        vector=parameters, xp=jnp
+    )
+    return factor_graph.log_likelihood_function(instance)
+
+
+params_jit = jnp.array(
+    factor_graph.global_prior_model.physical_values_from_prior_medians
+)
+log_l_jit = log_l_jit_fn(params_jit)
+
+print("JIT log_likelihood_function:", log_l_jit)
+assert isinstance(log_l_jit, jnp.ndarray), (
+    f"expected jax.Array, got {type(log_l_jit)}"
+)
+np.testing.assert_allclose(float(log_l_jit), log_l_np, rtol=1e-2)
+print("PASS: jit(log_likelihood_function) round-trip matches NumPy scalar.")

--- a/scripts/jax_likelihood_functions/multi/lp.py
+++ b/scripts/jax_likelihood_functions/multi/lp.py
@@ -1,0 +1,211 @@
+"""
+JAX Likelihood: Parametric Light Profile (Multi-Wavelength)
+============================================================
+
+Verify that JAX can compute the log-likelihood of a multi-wavelength
+``Imaging`` fit for an autogalaxy model composed of a Sersic bulge. Two paths
+are exercised:
+
+1. ``fitness._vmap`` batch evaluation over a ``af.FactorGraphModel`` that
+   combines per-band ``AnalysisImaging`` factors (tests ``jax.vmap`` +
+   ``jax.jit`` on the autofit ``Fitness`` wrapper).
+2. ``jax.jit`` over a parameter-vector entry point that mirrors what
+   ``fitness._vmap`` does internally:
+   ``instance_from_vector`` → ``factor_graph.log_likelihood_function``.
+   ``FactorGraphModel`` does not expose a ``fit_from`` method (it sums each
+   child factor's log-likelihood), so this is the multi-dataset analogue of
+   Path A from the single-dataset scripts.
+
+Uses **option B** — per-band ``galaxy.bulge.ell_comps_{0,1}`` priors via
+``model.copy()`` + ``af.GaussianPrior`` on each ``AnalysisFactor``. All other
+parameters stay shared across the g and r bands.
+"""
+
+from os import path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import autofit as af
+import autogalaxy as ag
+
+
+waveband_list = ["g", "r"]
+pixel_scales = 0.1
+mask_radius = 3.0
+
+dataset_path = path.join("dataset", "multi", "jax_test")
+
+if not path.exists(path.join(dataset_path, "g_data.fits")):
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/jax_likelihood_functions/multi/simulator.py"],
+        check=True,
+    )
+
+dataset_list = [
+    ag.Imaging.from_fits(
+        data_path=path.join(dataset_path, f"{band}_data.fits"),
+        psf_path=path.join(dataset_path, f"{band}_psf.fits"),
+        noise_map_path=path.join(dataset_path, f"{band}_noise_map.fits"),
+        pixel_scales=pixel_scales,
+    )
+    for band in waveband_list
+]
+
+mask_list = [
+    ag.Mask2D.circular(
+        shape_native=dataset.shape_native,
+        pixel_scales=dataset.pixel_scales,
+        radius=mask_radius,
+    )
+    for dataset in dataset_list
+]
+
+dataset_list = [
+    dataset.apply_mask(mask=mask) for dataset, mask in zip(dataset_list, mask_list)
+]
+dataset_list = [
+    dataset.apply_over_sampling(over_sample_size_lp=1) for dataset in dataset_list
+]
+
+"""
+__Model__
+
+Single galaxy with a Sersic bulge — no lens/source split, no mass profile.
+"""
+bulge = af.Model(ag.lp.Sersic)
+galaxy = af.Model(ag.Galaxy, redshift=0.5, bulge=bulge)
+model = af.Collection(galaxies=af.Collection(galaxy=galaxy))
+
+print(model.info)
+
+"""
+__Per-band models (option B)__
+
+Each band gets its own ``model.copy()`` with independent ``galaxy.bulge.ell_comps``
+priors to capture chromatic shape differences. Everything else stays shared.
+"""
+model_per_band_list = []
+for _ in waveband_list:
+    model_analysis = model.copy()
+    model_analysis.galaxies.galaxy.bulge.ell_comps.ell_comps_0 = af.GaussianPrior(
+        mean=0.0, sigma=0.5
+    )
+    model_analysis.galaxies.galaxy.bulge.ell_comps.ell_comps_1 = af.GaussianPrior(
+        mean=0.0, sigma=0.5
+    )
+    model_per_band_list.append(model_analysis)
+
+"""
+__FactorGraphModel (vmap path)__
+"""
+analysis_list = [ag.AnalysisImaging(dataset=dataset) for dataset in dataset_list]
+
+analysis_factor_list = [
+    af.AnalysisFactor(prior_model=m, analysis=analysis)
+    for m, analysis in zip(model_per_band_list, analysis_list)
+]
+
+factor_graph = af.FactorGraphModel(*analysis_factor_list, use_jax=True)
+
+print(factor_graph.global_prior_model.info)
+
+from autofit.non_linear.fitness import Fitness
+import time
+
+batch_size = 3
+
+fitness = Fitness(
+    model=factor_graph.global_prior_model,
+    analysis=factor_graph,
+    fom_is_log_likelihood=True,
+    resample_figure_of_merit=-1.0e99,
+)
+
+parameters = np.zeros(
+    (batch_size, factor_graph.global_prior_model.total_free_parameters)
+)
+for i in range(batch_size):
+    parameters[i, :] = (
+        factor_graph.global_prior_model.physical_values_from_prior_medians
+    )
+parameters = jnp.array(parameters)
+
+start = time.time()
+result = fitness._vmap(parameters)
+print(result)
+print("JAX Time To VMAP + JIT Function:", time.time() - start)
+
+start = time.time()
+result = fitness._vmap(parameters)
+print("JAX Time Taken using VMAP:", time.time() - start)
+print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
+
+
+"""
+__Path A: jit-wrap ``factor_graph.log_likelihood_function``__
+
+``FactorGraphModel`` has no ``fit_from`` method, so Path A jit-wraps a
+parameter-vector entry point that mirrors what ``fitness._vmap`` does
+internally: ``instance_from_vector`` → ``log_likelihood_function``. Passing a
+pre-built instance directly is not viable because
+``GlobalPriorModel.__init__`` stores a reference back to the ``FactorGraphModel``
+on the instance, and JAX pytree-flattens the whole instance and chokes on
+that non-registered leaf.
+"""
+from autofit.jax.pytrees import enable_pytrees, register_model
+
+enable_pytrees()
+register_model(factor_graph.global_prior_model)
+
+analysis_np_list = [
+    ag.AnalysisImaging(dataset=dataset, use_jax=False) for dataset in dataset_list
+]
+analysis_factor_np_list = [
+    af.AnalysisFactor(prior_model=m, analysis=a)
+    for m, a in zip(model_per_band_list, analysis_np_list)
+]
+factor_graph_np = af.FactorGraphModel(*analysis_factor_np_list, use_jax=False)
+
+params_np = np.array(
+    factor_graph_np.global_prior_model.physical_values_from_prior_medians
+)
+instance_np = factor_graph_np.global_prior_model.instance_from_vector(
+    vector=params_np, xp=np
+)
+log_l_np = float(factor_graph_np.log_likelihood_function(instance_np))
+print("NumPy log_likelihood_function:", log_l_np)
+
+analysis_jit_list = [
+    ag.AnalysisImaging(dataset=dataset, use_jax=True) for dataset in dataset_list
+]
+analysis_factor_jit_list = [
+    af.AnalysisFactor(prior_model=m, analysis=a)
+    for m, a in zip(model_per_band_list, analysis_jit_list)
+]
+factor_graph_jit = af.FactorGraphModel(*analysis_factor_jit_list, use_jax=True)
+
+
+@jax.jit
+def log_l_jit_fn(parameters):
+    instance = factor_graph_jit.global_prior_model.instance_from_vector(
+        vector=parameters, xp=jnp
+    )
+    return factor_graph_jit.log_likelihood_function(instance)
+
+
+params_jit = jnp.array(
+    factor_graph_jit.global_prior_model.physical_values_from_prior_medians
+)
+log_l_jit = log_l_jit_fn(params_jit)
+
+print("JIT log_likelihood_function:", log_l_jit)
+assert isinstance(log_l_jit, jnp.ndarray), (
+    f"expected jax.Array, got {type(log_l_jit)}"
+)
+np.testing.assert_allclose(float(log_l_jit), log_l_np, rtol=1e-4)
+print("PASS: jit(log_likelihood_function) round-trip matches NumPy scalar.")

--- a/scripts/jax_likelihood_functions/multi/mge.py
+++ b/scripts/jax_likelihood_functions/multi/mge.py
@@ -1,0 +1,216 @@
+"""
+JAX Likelihood: MGE Basis Light Profile (Multi-Wavelength)
+==========================================================
+
+Verify that JAX can compute the log-likelihood of a multi-wavelength
+``Imaging`` fit for an autogalaxy model composed of an MGE linear basis.
+Two paths are exercised:
+
+1. ``fitness._vmap`` batch evaluation over a ``af.FactorGraphModel`` that
+   combines per-band ``AnalysisImaging`` factors (tests ``jax.vmap`` +
+   ``jax.jit`` on the autofit ``Fitness`` wrapper).
+2. ``jax.jit`` over a parameter-vector entry point that mirrors what
+   ``fitness._vmap`` does internally:
+   ``instance_from_vector`` → ``factor_graph.log_likelihood_function``.
+   ``FactorGraphModel`` does not expose a ``fit_from`` method (it sums each
+   child factor's log-likelihood), so this is the multi-dataset analogue of
+   Path A from the single-dataset scripts.
+
+Uses **option B** — per-band ``galaxy.bulge`` MGE ``ell_comps`` priors via
+``model.copy()`` + ``af.GaussianPrior`` on each ``AnalysisFactor``. All other
+parameters stay shared across the g and r bands.
+"""
+
+from os import path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import autofit as af
+import autogalaxy as ag
+
+
+waveband_list = ["g", "r"]
+pixel_scales = 0.1
+mask_radius = 3.0
+
+dataset_path = path.join("dataset", "multi", "jax_test")
+
+if not path.exists(path.join(dataset_path, "g_data.fits")):
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/jax_likelihood_functions/multi/simulator.py"],
+        check=True,
+    )
+
+dataset_list = [
+    ag.Imaging.from_fits(
+        data_path=path.join(dataset_path, f"{band}_data.fits"),
+        psf_path=path.join(dataset_path, f"{band}_psf.fits"),
+        noise_map_path=path.join(dataset_path, f"{band}_noise_map.fits"),
+        pixel_scales=pixel_scales,
+    )
+    for band in waveband_list
+]
+
+mask_list = [
+    ag.Mask2D.circular(
+        shape_native=dataset.shape_native,
+        pixel_scales=dataset.pixel_scales,
+        radius=mask_radius,
+    )
+    for dataset in dataset_list
+]
+
+dataset_list = [
+    dataset.apply_mask(mask=mask) for dataset, mask in zip(dataset_list, mask_list)
+]
+dataset_list = [
+    dataset.apply_over_sampling(over_sample_size_lp=1) for dataset in dataset_list
+]
+
+"""
+__Model__
+
+Single galaxy with an MGE linear basis light profile — no lens/source split,
+no mass profile.
+"""
+bulge = ag.model_util.mge_model_from(
+    mask_radius=mask_radius, total_gaussians=20, centre_prior_is_uniform=True
+)
+
+galaxy = af.Model(ag.Galaxy, redshift=0.5, bulge=bulge)
+model = af.Collection(galaxies=af.Collection(galaxy=galaxy))
+
+print(model.info)
+
+"""
+__Per-band models (option B)__
+
+Each band gets its own ``model.copy()`` with independent ``galaxy.bulge`` MGE
+``ell_comps`` priors to capture chromatic shape differences. All gaussians
+within the Basis share one ell_comps prior pair per basis; we re-tie them to
+a fresh pair per factor so each band gets its own shape freedom.
+"""
+model_per_band_list = []
+for _ in waveband_list:
+    model_analysis = model.copy()
+    ec_0 = af.GaussianPrior(mean=0.0, sigma=0.5)
+    ec_1 = af.GaussianPrior(mean=0.0, sigma=0.5)
+    for gaussian in model_analysis.galaxies.galaxy.bulge.profile_list:
+        gaussian.ell_comps.ell_comps_0 = ec_0
+        gaussian.ell_comps.ell_comps_1 = ec_1
+    model_per_band_list.append(model_analysis)
+
+"""
+__FactorGraphModel (vmap path)__
+"""
+analysis_list = [ag.AnalysisImaging(dataset=dataset) for dataset in dataset_list]
+
+analysis_factor_list = [
+    af.AnalysisFactor(prior_model=m, analysis=analysis)
+    for m, analysis in zip(model_per_band_list, analysis_list)
+]
+
+factor_graph = af.FactorGraphModel(*analysis_factor_list, use_jax=True)
+
+print(factor_graph.global_prior_model.info)
+
+from autofit.non_linear.fitness import Fitness
+import time
+
+batch_size = 3
+
+fitness = Fitness(
+    model=factor_graph.global_prior_model,
+    analysis=factor_graph,
+    fom_is_log_likelihood=True,
+    resample_figure_of_merit=-1.0e99,
+)
+
+parameters = np.zeros(
+    (batch_size, factor_graph.global_prior_model.total_free_parameters)
+)
+for i in range(batch_size):
+    parameters[i, :] = (
+        factor_graph.global_prior_model.physical_values_from_prior_medians
+    )
+parameters = jnp.array(parameters)
+
+start = time.time()
+result = fitness._vmap(parameters)
+print(result)
+print("JAX Time To VMAP + JIT Function:", time.time() - start)
+
+start = time.time()
+result = fitness._vmap(parameters)
+print("JAX Time Taken using VMAP:", time.time() - start)
+print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
+
+
+"""
+__Path A: jit-wrap ``factor_graph.log_likelihood_function``__
+
+``FactorGraphModel`` has no ``fit_from`` method, so Path A jit-wraps a
+parameter-vector entry point that mirrors what ``fitness._vmap`` does
+internally: ``instance_from_vector`` → ``log_likelihood_function``. Passing a
+pre-built instance directly is not viable because
+``GlobalPriorModel.__init__`` stores a reference back to the ``FactorGraphModel``
+on the instance, and JAX pytree-flattens the whole instance and chokes on
+that non-registered leaf.
+"""
+from autofit.jax.pytrees import enable_pytrees, register_model
+
+enable_pytrees()
+register_model(factor_graph.global_prior_model)
+
+analysis_np_list = [
+    ag.AnalysisImaging(dataset=dataset, use_jax=False) for dataset in dataset_list
+]
+analysis_factor_np_list = [
+    af.AnalysisFactor(prior_model=m, analysis=a)
+    for m, a in zip(model_per_band_list, analysis_np_list)
+]
+factor_graph_np = af.FactorGraphModel(*analysis_factor_np_list, use_jax=False)
+
+params_np = np.array(
+    factor_graph_np.global_prior_model.physical_values_from_prior_medians
+)
+instance_np = factor_graph_np.global_prior_model.instance_from_vector(
+    vector=params_np, xp=np
+)
+log_l_np = float(factor_graph_np.log_likelihood_function(instance_np))
+print("NumPy log_likelihood_function:", log_l_np)
+
+analysis_jit_list = [
+    ag.AnalysisImaging(dataset=dataset, use_jax=True) for dataset in dataset_list
+]
+analysis_factor_jit_list = [
+    af.AnalysisFactor(prior_model=m, analysis=a)
+    for m, a in zip(model_per_band_list, analysis_jit_list)
+]
+factor_graph_jit = af.FactorGraphModel(*analysis_factor_jit_list, use_jax=True)
+
+
+@jax.jit
+def log_l_jit_fn(parameters):
+    instance = factor_graph_jit.global_prior_model.instance_from_vector(
+        vector=parameters, xp=jnp
+    )
+    return factor_graph_jit.log_likelihood_function(instance)
+
+
+params_jit = jnp.array(
+    factor_graph_jit.global_prior_model.physical_values_from_prior_medians
+)
+log_l_jit = log_l_jit_fn(params_jit)
+
+print("JIT log_likelihood_function:", log_l_jit)
+assert isinstance(log_l_jit, jnp.ndarray), (
+    f"expected jax.Array, got {type(log_l_jit)}"
+)
+np.testing.assert_allclose(float(log_l_jit), log_l_np, rtol=1e-4)
+print("PASS: jit(log_likelihood_function) round-trip matches NumPy scalar.")

--- a/scripts/jax_likelihood_functions/multi/mge_group.py
+++ b/scripts/jax_likelihood_functions/multi/mge_group.py
@@ -1,0 +1,257 @@
+"""
+JAX Likelihood: MGE Basis Light Profile with Extra Galaxies (Multi-Wavelength)
+===============================================================================
+
+Verify that JAX can compute the log-likelihood of a multi-wavelength
+``Imaging`` fit for an autogalaxy model composed of an MGE linear basis on the
+primary galaxy plus extra galaxies (each with a spherical MGE linear basis).
+Two paths are exercised:
+
+1. ``fitness._vmap`` batch evaluation over a ``af.FactorGraphModel`` that
+   combines per-band ``AnalysisImaging`` factors.
+2. ``jax.jit`` over a parameter-vector entry point:
+   ``instance_from_vector`` → ``factor_graph.log_likelihood_function``.
+
+Uses **option B** — per-band ``galaxy.bulge`` MGE ``ell_comps`` priors via
+``model.copy()`` + ``af.GaussianPrior`` on each ``AnalysisFactor``. The extra
+galaxies stay shared across bands.
+"""
+
+from os import path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import autofit as af
+import autogalaxy as ag
+
+
+waveband_list = ["g", "r"]
+pixel_scales = 0.1
+mask_radius = 3.0
+
+dataset_path = path.join("dataset", "multi", "jax_test")
+
+if not path.exists(path.join(dataset_path, "g_data.fits")):
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/jax_likelihood_functions/multi/simulator.py"],
+        check=True,
+    )
+
+dataset_list = [
+    ag.Imaging.from_fits(
+        data_path=path.join(dataset_path, f"{band}_data.fits"),
+        psf_path=path.join(dataset_path, f"{band}_psf.fits"),
+        noise_map_path=path.join(dataset_path, f"{band}_noise_map.fits"),
+        pixel_scales=pixel_scales,
+    )
+    for band in waveband_list
+]
+
+mask_list = [
+    ag.Mask2D.circular(
+        shape_native=dataset.shape_native,
+        pixel_scales=dataset.pixel_scales,
+        radius=mask_radius,
+    )
+    for dataset in dataset_list
+]
+
+dataset_list = [
+    dataset.apply_mask(mask=mask) for dataset, mask in zip(dataset_list, mask_list)
+]
+dataset_list = [
+    dataset.apply_over_sampling(over_sample_size_lp=1) for dataset in dataset_list
+]
+
+"""
+__Group Centres__
+
+The multi simulator does not include extra galaxies, so the extra-galaxy
+components here have no data support. They still exercise the MGE +
+``extra_galaxies`` wiring through the JAX factor graph.
+"""
+centre_list = [(0.0, 1.0), (1.0, 0.0)]
+
+"""
+__Model__
+
+Primary galaxy with a large MGE bulge. Extra galaxies with spherical MGE
+bases. No mass profiles, no lens/source split.
+"""
+total_gaussians = 20
+gaussian_per_basis = 2
+log10_sigma_list = np.linspace(-2, np.log10(mask_radius), total_gaussians)
+
+centre_0 = af.UniformPrior(lower_limit=-0.1, upper_limit=0.1)
+centre_1 = af.UniformPrior(lower_limit=-0.1, upper_limit=0.1)
+
+bulge_gaussian_list = []
+for j in range(gaussian_per_basis):
+    gaussian_list = af.Collection(
+        af.Model(ag.lp_linear.Gaussian) for _ in range(total_gaussians)
+    )
+    for i, gaussian in enumerate(gaussian_list):
+        gaussian.centre.centre_0 = centre_0
+        gaussian.centre.centre_1 = centre_1
+        gaussian.ell_comps = gaussian_list[0].ell_comps
+        gaussian.sigma = 10 ** log10_sigma_list[i]
+    bulge_gaussian_list += gaussian_list
+
+bulge = af.Model(ag.lp_basis.Basis, profile_list=bulge_gaussian_list)
+
+galaxy = af.Model(ag.Galaxy, redshift=0.5, bulge=bulge)
+
+# Extra Galaxies:
+extra_galaxies_list = []
+
+for extra_galaxy_centre in centre_list:
+    total_gaussians = 8
+    log10_sigma_list = np.linspace(-2, np.log10(mask_radius), total_gaussians)
+
+    eg_gaussian_list = af.Collection(
+        af.Model(ag.lp_linear.GaussianSph) for _ in range(total_gaussians)
+    )
+    for i, gaussian in enumerate(eg_gaussian_list):
+        gaussian.centre.centre_0 = extra_galaxy_centre[0]
+        gaussian.centre.centre_1 = extra_galaxy_centre[1]
+        gaussian.sigma = 10 ** log10_sigma_list[i]
+
+    extra_galaxy_bulge = af.Model(ag.lp_basis.Basis, profile_list=eg_gaussian_list)
+
+    extra_galaxy = af.Model(ag.Galaxy, redshift=0.5, bulge=extra_galaxy_bulge)
+    extra_galaxies_list.append(extra_galaxy)
+
+extra_galaxies = af.Collection(extra_galaxies_list)
+
+model = af.Collection(
+    galaxies=af.Collection(galaxy=galaxy), extra_galaxies=extra_galaxies
+)
+
+print(model.info)
+
+"""
+__Per-band models (option B)__
+
+Each band gets its own ``model.copy()`` with independent primary-galaxy MGE
+``ell_comps`` priors. The extra galaxies stay shared.
+"""
+model_per_band_list = []
+for _ in waveband_list:
+    model_analysis = model.copy()
+    ec_0 = af.GaussianPrior(mean=0.0, sigma=0.5)
+    ec_1 = af.GaussianPrior(mean=0.0, sigma=0.5)
+    for gaussian in model_analysis.galaxies.galaxy.bulge.profile_list:
+        gaussian.ell_comps.ell_comps_0 = ec_0
+        gaussian.ell_comps.ell_comps_1 = ec_1
+    model_per_band_list.append(model_analysis)
+
+"""
+__FactorGraphModel (vmap path)__
+"""
+analysis_list = [ag.AnalysisImaging(dataset=dataset) for dataset in dataset_list]
+
+analysis_factor_list = [
+    af.AnalysisFactor(prior_model=m, analysis=analysis)
+    for m, analysis in zip(model_per_band_list, analysis_list)
+]
+
+factor_graph = af.FactorGraphModel(*analysis_factor_list, use_jax=True)
+
+print(factor_graph.global_prior_model.info)
+
+from autofit.non_linear.fitness import Fitness
+import time
+
+batch_size = 3
+
+fitness = Fitness(
+    model=factor_graph.global_prior_model,
+    analysis=factor_graph,
+    fom_is_log_likelihood=True,
+    resample_figure_of_merit=-1.0e99,
+)
+
+parameters = np.zeros(
+    (batch_size, factor_graph.global_prior_model.total_free_parameters)
+)
+for i in range(batch_size):
+    parameters[i, :] = (
+        factor_graph.global_prior_model.physical_values_from_prior_medians
+    )
+parameters = jnp.array(parameters)
+
+start = time.time()
+result = fitness._vmap(parameters)
+print(result)
+print("JAX Time To VMAP + JIT Function:", time.time() - start)
+
+start = time.time()
+result = fitness._vmap(parameters)
+print("JAX Time Taken using VMAP:", time.time() - start)
+print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
+
+
+"""
+__Path A: jit-wrap ``factor_graph.log_likelihood_function``__
+"""
+from autofit.jax.pytrees import enable_pytrees, register_model
+
+enable_pytrees()
+register_model(factor_graph.global_prior_model)
+
+analysis_np_list = [
+    ag.AnalysisImaging(dataset=dataset, use_jax=False) for dataset in dataset_list
+]
+factor_graph_np = af.FactorGraphModel(
+    *[
+        af.AnalysisFactor(prior_model=m, analysis=a)
+        for m, a in zip(model_per_band_list, analysis_np_list)
+    ],
+    use_jax=False,
+)
+
+params_np = np.array(
+    factor_graph_np.global_prior_model.physical_values_from_prior_medians
+)
+instance_np = factor_graph_np.global_prior_model.instance_from_vector(
+    vector=params_np, xp=np
+)
+log_l_np = float(factor_graph_np.log_likelihood_function(instance_np))
+print("NumPy log_likelihood_function:", log_l_np)
+
+analysis_jit_list = [
+    ag.AnalysisImaging(dataset=dataset, use_jax=True) for dataset in dataset_list
+]
+factor_graph_jit = af.FactorGraphModel(
+    *[
+        af.AnalysisFactor(prior_model=m, analysis=a)
+        for m, a in zip(model_per_band_list, analysis_jit_list)
+    ],
+    use_jax=True,
+)
+
+
+@jax.jit
+def log_l_jit_fn(parameters):
+    instance = factor_graph_jit.global_prior_model.instance_from_vector(
+        vector=parameters, xp=jnp
+    )
+    return factor_graph_jit.log_likelihood_function(instance)
+
+
+params_jit = jnp.array(
+    factor_graph_jit.global_prior_model.physical_values_from_prior_medians
+)
+log_l_jit = log_l_jit_fn(params_jit)
+
+print("JIT log_likelihood_function:", log_l_jit)
+assert isinstance(log_l_jit, jnp.ndarray), (
+    f"expected jax.Array, got {type(log_l_jit)}"
+)
+np.testing.assert_allclose(float(log_l_jit), log_l_np, rtol=1e-4)
+print("PASS: jit(log_likelihood_function) round-trip matches NumPy scalar.")

--- a/scripts/jax_likelihood_functions/multi/rectangular.py
+++ b/scripts/jax_likelihood_functions/multi/rectangular.py
@@ -1,0 +1,245 @@
+"""
+JAX Likelihood: Rectangular Adapt-Image Pixelization (Multi-Wavelength)
+========================================================================
+
+Verify that JAX can compute the log-likelihood of a multi-wavelength
+``Imaging`` fit for an autogalaxy model using an adapt-image rectangular
+pixelization (``RectangularAdaptImage`` + ``Adapt`` regularization).
+Two paths are exercised:
+
+1. ``fitness._vmap`` batch evaluation over a ``af.FactorGraphModel`` that
+   combines per-band ``AnalysisImaging`` factors.
+2. ``jax.jit`` over a parameter-vector entry point:
+   ``instance_from_vector`` → ``factor_graph.log_likelihood_function``.
+
+Uses **option B** — per-band ``galaxy.pixelization.regularization.inner_coefficient``
+priors via ``model.copy()`` + ``af.GaussianPrior`` on each ``AnalysisFactor``.
+This is the pixelized analogue of "per-band shape": each band gets its own
+regularization strength.
+
+Path A asserts JIT round-trip parity with the vmap result. For pixelized
+models, ``analysis.log_likelihood_function`` under ``use_jax=True`` takes a
+different numerical path than under ``use_jax=False`` (the JAX path matches
+``fit.log_likelihood`` only when routed through ``fit_from``, which
+``FactorGraphModel`` does not expose).
+"""
+
+from os import path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import autofit as af
+import autogalaxy as ag
+
+
+waveband_list = ["g", "r"]
+pixel_scales = 0.1
+mask_radius = 3.0
+
+dataset_path = path.join("dataset", "multi", "jax_test")
+
+if not path.exists(path.join(dataset_path, "g_data.fits")):
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/jax_likelihood_functions/multi/simulator.py"],
+        check=True,
+    )
+
+dataset_list = [
+    ag.Imaging.from_fits(
+        data_path=path.join(dataset_path, f"{band}_data.fits"),
+        psf_path=path.join(dataset_path, f"{band}_psf.fits"),
+        noise_map_path=path.join(dataset_path, f"{band}_noise_map.fits"),
+        pixel_scales=pixel_scales,
+    )
+    for band in waveband_list
+]
+
+mask_list = [
+    ag.Mask2D.circular(
+        shape_native=dataset.shape_native,
+        pixel_scales=dataset.pixel_scales,
+        radius=mask_radius,
+    )
+    for dataset in dataset_list
+]
+
+dataset_list = [
+    dataset.apply_mask(mask=mask) for dataset, mask in zip(dataset_list, mask_list)
+]
+dataset_list = [
+    dataset.apply_over_sampling(
+        over_sample_size_lp=1, over_sample_size_pixelization=1
+    )
+    for dataset in dataset_list
+]
+
+"""
+__Mesh & Adapt Images (per band)__
+
+The galaxy is named ``galaxy`` in the model, so the path tuple is
+``('galaxies', 'galaxy')``. ``dataset.data`` is used as a stand-in for the
+"previous-fit" galaxy image.
+"""
+mesh_pixels_yx = 28
+mesh_shape = (mesh_pixels_yx, mesh_pixels_yx)
+
+adapt_images_list = [
+    ag.AdaptImages(
+        galaxy_name_image_dict={
+            "('galaxies', 'galaxy')": dataset.data,
+        }
+    )
+    for dataset in dataset_list
+]
+
+"""
+__Model__
+
+Single galaxy with an adapt-image rectangular pixelization. The mesh shape is
+fixed (28 x 28) per the JAX static-shape requirement.
+"""
+pixelization = af.Model(
+    ag.Pixelization,
+    mesh=ag.mesh.RectangularAdaptImage(shape=mesh_shape, weight_power=1.0),
+    regularization=ag.reg.Adapt,
+)
+
+galaxy = af.Model(ag.Galaxy, redshift=0.5, pixelization=pixelization)
+model = af.Collection(galaxies=af.Collection(galaxy=galaxy))
+
+print(model.info)
+
+"""
+__Per-band models (option B)__
+
+Each band gets its own ``model.copy()`` with an independent prior on the
+regularization ``coefficient``. This is the pixelized analogue of "per-band
+shape": each band picks its own regularization strength.
+"""
+model_per_band_list = []
+for _ in waveband_list:
+    model_analysis = model.copy()
+    model_analysis.galaxies.galaxy.pixelization.regularization.inner_coefficient = (
+        af.GaussianPrior(mean=1.0, sigma=0.5)
+    )
+    model_per_band_list.append(model_analysis)
+
+"""
+__FactorGraphModel (vmap path)__
+"""
+analysis_list = [
+    ag.AnalysisImaging(
+        dataset=dataset,
+        adapt_images=adapt_images,
+        settings=ag.Settings(use_border_relocator=True),
+    )
+    for dataset, adapt_images in zip(dataset_list, adapt_images_list)
+]
+
+analysis_factor_list = [
+    af.AnalysisFactor(prior_model=m, analysis=analysis)
+    for m, analysis in zip(model_per_band_list, analysis_list)
+]
+
+factor_graph = af.FactorGraphModel(*analysis_factor_list, use_jax=True)
+
+print(factor_graph.global_prior_model.info)
+
+from autofit.non_linear.fitness import Fitness
+import time
+
+batch_size = 3
+
+fitness = Fitness(
+    model=factor_graph.global_prior_model,
+    analysis=factor_graph,
+    fom_is_log_likelihood=True,
+    resample_figure_of_merit=-1.0e99,
+)
+
+parameters = np.zeros(
+    (batch_size, factor_graph.global_prior_model.total_free_parameters)
+)
+for i in range(batch_size):
+    parameters[i, :] = (
+        factor_graph.global_prior_model.physical_values_from_prior_medians
+    )
+parameters = jnp.array(parameters)
+
+start = time.time()
+result = fitness._vmap(parameters)
+print(result)
+print("JAX Time To VMAP + JIT Function:", time.time() - start)
+
+start = time.time()
+result = fitness._vmap(parameters)
+print("JAX Time Taken using VMAP:", time.time() - start)
+print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
+
+
+"""
+__Path A: jit-wrap ``factor_graph.log_likelihood_function``__
+
+``FactorGraphModel`` has no ``fit_from`` method, so Path A jit-wraps a
+parameter-vector entry point that mirrors what ``fitness._vmap`` does
+internally: ``instance_from_vector`` → ``log_likelihood_function``.
+
+Pixelizations with adapt regularization run a sparse linear solve whose
+NumPy vs JAX float-ordering drift typically lands at ~1% — same as the
+single-dataset autogalaxy ``imaging/rectangular.py`` and
+``interferometer/rectangular.py``, so the rtol=1e-2 convention applies.
+"""
+from autofit.jax.pytrees import enable_pytrees, register_model
+
+enable_pytrees()
+register_model(factor_graph.global_prior_model)
+
+analysis_np_list = [
+    ag.AnalysisImaging(
+        dataset=dataset,
+        adapt_images=adapt_images,
+        settings=ag.Settings(use_border_relocator=True),
+        use_jax=False,
+    )
+    for dataset, adapt_images in zip(dataset_list, adapt_images_list)
+]
+analysis_factor_np_list = [
+    af.AnalysisFactor(prior_model=m, analysis=a)
+    for m, a in zip(model_per_band_list, analysis_np_list)
+]
+factor_graph_np = af.FactorGraphModel(*analysis_factor_np_list, use_jax=False)
+
+params_np = np.array(
+    factor_graph_np.global_prior_model.physical_values_from_prior_medians
+)
+instance_np = factor_graph_np.global_prior_model.instance_from_vector(
+    vector=params_np, xp=np
+)
+log_l_np = float(factor_graph_np.log_likelihood_function(instance_np))
+print("NumPy log_likelihood_function:", log_l_np)
+
+
+@jax.jit
+def log_l_jit_fn(parameters):
+    instance = factor_graph.global_prior_model.instance_from_vector(
+        vector=parameters, xp=jnp
+    )
+    return factor_graph.log_likelihood_function(instance)
+
+
+params_jit = jnp.array(
+    factor_graph.global_prior_model.physical_values_from_prior_medians
+)
+log_l_jit = log_l_jit_fn(params_jit)
+
+print("JIT log_likelihood_function:", log_l_jit)
+assert isinstance(log_l_jit, jnp.ndarray), (
+    f"expected jax.Array, got {type(log_l_jit)}"
+)
+np.testing.assert_allclose(float(log_l_jit), log_l_np, rtol=1e-2)
+print("PASS: jit(log_likelihood_function) round-trip matches NumPy scalar.")

--- a/scripts/jax_likelihood_functions/multi/rectangular_mge.py
+++ b/scripts/jax_likelihood_functions/multi/rectangular_mge.py
@@ -1,0 +1,254 @@
+"""
+JAX Likelihood: Rectangular Adapt-Image Pixelization + MGE Bulge (Multi-Wavelength)
+=====================================================================================
+
+Verify that JAX can compute the log-likelihood of a multi-wavelength
+``Imaging`` fit for an autogalaxy model with two galaxies:
+  - galaxy_0: MGE bulge (provides linear light profiles)
+  - galaxy_1: adapt-image rectangular pixelization + Constant regularization
+
+Two paths are exercised:
+
+1. ``fitness._vmap`` batch evaluation over a ``af.FactorGraphModel`` that
+   combines per-band ``AnalysisImaging`` factors.
+2. ``jax.jit`` over a parameter-vector entry point:
+   ``instance_from_vector`` → ``factor_graph.log_likelihood_function``.
+
+Uses **option B** — per-band ``galaxy_1.pixelization.regularization.inner_coefficient``
+priors via ``model.copy()`` + ``af.GaussianPrior`` on each ``AnalysisFactor``.
+The MGE bulge parameters stay shared across bands.
+
+Path A asserts JIT round-trip parity with the vmap result (pixelized path
+differs between use_jax=True and use_jax=False).
+"""
+
+from os import path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import autofit as af
+import autogalaxy as ag
+
+
+waveband_list = ["g", "r"]
+pixel_scales = 0.1
+mask_radius = 3.0
+
+dataset_path = path.join("dataset", "multi", "jax_test")
+
+if not path.exists(path.join(dataset_path, "g_data.fits")):
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/jax_likelihood_functions/multi/simulator.py"],
+        check=True,
+    )
+
+dataset_list = [
+    ag.Imaging.from_fits(
+        data_path=path.join(dataset_path, f"{band}_data.fits"),
+        psf_path=path.join(dataset_path, f"{band}_psf.fits"),
+        noise_map_path=path.join(dataset_path, f"{band}_noise_map.fits"),
+        pixel_scales=pixel_scales,
+    )
+    for band in waveband_list
+]
+
+mask_list = [
+    ag.Mask2D.circular(
+        shape_native=dataset.shape_native,
+        pixel_scales=dataset.pixel_scales,
+        radius=mask_radius,
+    )
+    for dataset in dataset_list
+]
+
+dataset_list = [
+    dataset.apply_mask(mask=mask) for dataset, mask in zip(dataset_list, mask_list)
+]
+dataset_list = [
+    dataset.apply_over_sampling(
+        over_sample_size_lp=1, over_sample_size_pixelization=1
+    )
+    for dataset in dataset_list
+]
+
+"""
+__Mesh & Adapt Images (per band)__
+
+The model has two galaxies named ``galaxy_0`` (MGE bulge) and ``galaxy_1``
+(pixelization). Both are included in the dict to keep the path list aligned
+with all galaxies in the analysis.
+"""
+mesh_pixels_yx = 28
+mesh_shape = (mesh_pixels_yx, mesh_pixels_yx)
+
+adapt_images_list = [
+    ag.AdaptImages(
+        galaxy_name_image_dict={
+            "('galaxies', 'galaxy_0')": dataset.data,
+            "('galaxies', 'galaxy_1')": dataset.data,
+        }
+    )
+    for dataset in dataset_list
+]
+
+"""
+__Model__
+
+galaxy_0: MGE bulge — provides linear light profiles.
+galaxy_1: rectangular adapt-image pixelization.
+"""
+bulge = ag.model_util.mge_model_from(
+    mask_radius=mask_radius, total_gaussians=10, centre_prior_is_uniform=True
+)
+
+galaxy_0 = af.Model(ag.Galaxy, redshift=0.5, bulge=bulge)
+
+pixelization = af.Model(
+    ag.Pixelization,
+    mesh=ag.mesh.RectangularAdaptImage(shape=mesh_shape, weight_power=1.0),
+    regularization=ag.reg.Adapt,
+)
+
+galaxy_1 = af.Model(ag.Galaxy, redshift=0.5, pixelization=pixelization)
+
+model = af.Collection(
+    galaxies=af.Collection(galaxy_0=galaxy_0, galaxy_1=galaxy_1)
+)
+
+print(model.info)
+
+"""
+__Per-band models (option B)__
+
+Each band gets its own ``model.copy()`` with an independent prior on
+``galaxy_1.pixelization.regularization.inner_coefficient``.
+"""
+model_per_band_list = []
+for _ in waveband_list:
+    model_analysis = model.copy()
+    model_analysis.galaxies.galaxy_1.pixelization.regularization.inner_coefficient = (
+        af.GaussianPrior(mean=1.0, sigma=0.5)
+    )
+    model_per_band_list.append(model_analysis)
+
+"""
+__FactorGraphModel (vmap path)__
+"""
+settings = ag.Settings(use_border_relocator=True)
+
+analysis_list = [
+    ag.AnalysisImaging(
+        dataset=dataset,
+        adapt_images=adapt_images,
+        settings=settings,
+    )
+    for dataset, adapt_images in zip(dataset_list, adapt_images_list)
+]
+
+analysis_factor_list = [
+    af.AnalysisFactor(prior_model=m, analysis=analysis)
+    for m, analysis in zip(model_per_band_list, analysis_list)
+]
+
+factor_graph = af.FactorGraphModel(*analysis_factor_list, use_jax=True)
+
+print(factor_graph.global_prior_model.info)
+
+from autofit.non_linear.fitness import Fitness
+import time
+
+batch_size = 3
+
+fitness = Fitness(
+    model=factor_graph.global_prior_model,
+    analysis=factor_graph,
+    fom_is_log_likelihood=True,
+    resample_figure_of_merit=-1.0e99,
+)
+
+parameters = np.zeros(
+    (batch_size, factor_graph.global_prior_model.total_free_parameters)
+)
+for i in range(batch_size):
+    parameters[i, :] = (
+        factor_graph.global_prior_model.physical_values_from_prior_medians
+    )
+parameters = jnp.array(parameters)
+
+start = time.time()
+result = fitness._vmap(parameters)
+print(result)
+print("JAX Time To VMAP + JIT Function:", time.time() - start)
+
+start = time.time()
+result = fitness._vmap(parameters)
+print("JAX Time Taken using VMAP:", time.time() - start)
+print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
+
+
+"""
+__Path A: jit-wrap ``factor_graph.log_likelihood_function``__
+
+``FactorGraphModel`` has no ``fit_from`` method, so Path A jit-wraps a
+parameter-vector entry point that mirrors what ``fitness._vmap`` does
+internally: ``instance_from_vector`` → ``log_likelihood_function``.
+
+The adapt-regularization linear solve has ~1% NumPy/JAX float-ordering
+drift — same as the single-dataset autogalaxy ``imaging/rectangular_mge.py``
+and ``interferometer/rectangular_mge.py``, so the rtol=1e-2 convention
+applies.
+"""
+from autofit.jax.pytrees import enable_pytrees, register_model
+
+enable_pytrees()
+register_model(factor_graph.global_prior_model)
+
+analysis_np_list = [
+    ag.AnalysisImaging(
+        dataset=dataset,
+        adapt_images=adapt_images,
+        settings=settings,
+        use_jax=False,
+    )
+    for dataset, adapt_images in zip(dataset_list, adapt_images_list)
+]
+analysis_factor_np_list = [
+    af.AnalysisFactor(prior_model=m, analysis=a)
+    for m, a in zip(model_per_band_list, analysis_np_list)
+]
+factor_graph_np = af.FactorGraphModel(*analysis_factor_np_list, use_jax=False)
+
+params_np = np.array(
+    factor_graph_np.global_prior_model.physical_values_from_prior_medians
+)
+instance_np = factor_graph_np.global_prior_model.instance_from_vector(
+    vector=params_np, xp=np
+)
+log_l_np = float(factor_graph_np.log_likelihood_function(instance_np))
+print("NumPy log_likelihood_function:", log_l_np)
+
+
+@jax.jit
+def log_l_jit_fn(parameters):
+    instance = factor_graph.global_prior_model.instance_from_vector(
+        vector=parameters, xp=jnp
+    )
+    return factor_graph.log_likelihood_function(instance)
+
+
+params_jit = jnp.array(
+    factor_graph.global_prior_model.physical_values_from_prior_medians
+)
+log_l_jit = log_l_jit_fn(params_jit)
+
+print("JIT log_likelihood_function:", log_l_jit)
+assert isinstance(log_l_jit, jnp.ndarray), (
+    f"expected jax.Array, got {type(log_l_jit)}"
+)
+np.testing.assert_allclose(float(log_l_jit), log_l_np, rtol=1e-2)
+print("PASS: jit(log_likelihood_function) round-trip matches NumPy scalar.")

--- a/scripts/jax_likelihood_functions/multi/simulator.py
+++ b/scripts/jax_likelihood_functions/multi/simulator.py
@@ -1,0 +1,95 @@
+"""
+Simulator: JAX Multi-Wavelength Test Dataset
+============================================
+
+Simulates two-band (g and r) ``Imaging`` datasets consumed by every script in
+``scripts/jax_likelihood_functions/multi/``.
+
+A single galaxy with a Sersic bulge + Exponential disk is observed in two
+wavebands. Each band has a different bulge intensity to give chromatic
+variation, and a distinct noise seed. No lens / mass / source plane — this
+is single-plane autogalaxy data designed to exercise the JAX likelihood path
+through ``af.FactorGraphModel`` over multiple datasets.
+
+Output files (under ``dataset/multi/jax_test/``):
+
+- ``{g,r}_data.fits`` — simulated noisy images
+- ``{g,r}_psf.fits`` — Gaussian PSF kernels
+- ``{g,r}_noise_map.fits`` — per-pixel 1-sigma noise maps
+- ``galaxies.json`` — the g-band ``Galaxies`` (the r-band variant differs only
+  by ``bulge.intensity``), for reproducibility
+"""
+
+from pathlib import Path
+
+import autogalaxy as ag
+
+
+dataset_path = Path("dataset", "multi", "jax_test")
+dataset_path.mkdir(parents=True, exist_ok=True)
+
+grid = ag.Grid2D.uniform(shape_native=(150, 150), pixel_scales=0.1)
+
+psf = ag.Convolver.from_gaussian(
+    shape_native=(21, 21), sigma=0.1, pixel_scales=grid.pixel_scales, normalize=True
+)
+
+
+def _galaxies_for_band(bulge_intensity: float) -> ag.Galaxies:
+    galaxy = ag.Galaxy(
+        redshift=0.5,
+        bulge=ag.lp.Sersic(
+            centre=(0.0, 0.0),
+            ell_comps=ag.convert.ell_comps_from(axis_ratio=0.9, angle=45.0),
+            intensity=bulge_intensity,
+            effective_radius=0.6,
+            sersic_index=3.0,
+        ),
+        disk=ag.lp.Exponential(
+            centre=(0.0, 0.0),
+            ell_comps=ag.convert.ell_comps_from(axis_ratio=0.7, angle=30.0),
+            intensity=0.5,
+            effective_radius=1.6,
+        ),
+    )
+    return ag.Galaxies(galaxies=[galaxy])
+
+
+# g-band: bulge intensity 1.0; r-band: bulge intensity 1.6 — chromatic variation.
+band_intensity = {"g": 1.0, "r": 1.6}
+band_seed = {"g": 1, "r": 2}
+
+for band, intensity in band_intensity.items():
+    simulator = ag.SimulatorImaging(
+        exposure_time=2000.0,
+        psf=psf,
+        background_sky_level=0.1,
+        add_poisson_noise_to_data=True,
+        noise_seed=band_seed[band],
+    )
+    galaxies = _galaxies_for_band(bulge_intensity=intensity)
+    dataset = simulator.via_galaxies_from(galaxies=galaxies, grid=grid)
+
+    ag.output_to_fits(
+        values=dataset.data.native,
+        file_path=dataset_path / f"{band}_data.fits",
+        overwrite=True,
+    )
+    ag.output_to_fits(
+        values=dataset.psf.kernel.native,
+        file_path=dataset_path / f"{band}_psf.fits",
+        overwrite=True,
+    )
+    ag.output_to_fits(
+        values=dataset.noise_map.native,
+        file_path=dataset_path / f"{band}_noise_map.fits",
+        overwrite=True,
+    )
+    if band == "g":
+        ag.output_to_json(
+            obj=galaxies,
+            file_path=dataset_path / "galaxies.json",
+        )
+    print(f"Saved {band}-band dataset")
+
+print("Multi-wavelength datasets written to", dataset_path)

--- a/smoke_tests.txt
+++ b/smoke_tests.txt
@@ -16,5 +16,12 @@ jax_likelihood_functions/interferometer/rectangular.py
 jax_likelihood_functions/interferometer/rectangular_mge.py
 jax_likelihood_functions/interferometer/delaunay.py
 jax_likelihood_functions/interferometer/delaunay_mge.py
+jax_likelihood_functions/multi/lp.py
+jax_likelihood_functions/multi/mge.py
+jax_likelihood_functions/multi/mge_group.py
+jax_likelihood_functions/multi/rectangular.py
+jax_likelihood_functions/multi/rectangular_mge.py
+jax_likelihood_functions/multi/delaunay.py
+jax_likelihood_functions/multi/delaunay_mge.py
 imaging/model_fit.py
 imaging/visualization.py


### PR DESCRIPTION
## Summary

Port the JAX-likelihood multi-dataset scripts from `autolens_workspace_test` to `autogalaxy_workspace_test`, mirroring the imaging port (#8 / PR #9) and the interferometer port (#16 / PR #17 — shipped earlier today). Each fit script combines per-band `ag.AnalysisImaging` factors via `af.FactorGraphModel` and asserts NumPy/JIT scalar parity over a parameter-vector entry point — `FactorGraphModel` has no `fit_from`, so Path A jit-wraps `instance_from_vector → log_likelihood_function` instead.

This is task 5/9 of the autogalaxy_workspace_test epic (#5).

**Note on what "multi" means here.** The original prompt described these as combining an imaging dataset with an interferometer dataset. The actual autolens reference scripts use **multi-band imaging** (g and r filters, both `AnalysisImaging`) — that's what this port mirrors. Single galaxy in autogalaxy with per-band variation under option B (per-band `bulge.ell_comps_{0,1}` for parametric variants, per-band `regularization.inner_coefficient` for pixelization variants).

## Scripts Changed

- `scripts/jax_likelihood_functions/multi/__init__.py` — new package marker
- `scripts/jax_likelihood_functions/multi/simulator.py` — generates the multi-band JAX-test dataset (single Sersic+Exponential galaxy, per-band bulge intensity 1.0/1.6, distinct noise seeds, no external fixtures)
- `scripts/jax_likelihood_functions/multi/lp.py` — parametric Sersic across g/r, NumPy/JIT parity at rtol=1e-4 (`-2626117682.295914` / `-2626117682.2959146`)
- `scripts/jax_likelihood_functions/multi/mge.py` — MGE bulge across g/r, NumPy/JIT parity at rtol=1e-4
- `scripts/jax_likelihood_functions/multi/mge_group.py` — MGE bulge + extra MGE galaxies across g/r, NumPy/JIT parity at rtol=1e-4
- `scripts/jax_likelihood_functions/multi/rectangular.py` — rectangular pixelization + adapt regularization across g/r, NumPy/JIT parity at rtol=1e-2 per the documented adapt-regularization-drift convention (actual rdiff 1.5e-5)
- `scripts/jax_likelihood_functions/multi/rectangular_mge.py` — MGE bulge + rectangular pixelization across g/r, rtol=1e-2 (actual rdiff 7.6e-5)
- `scripts/jax_likelihood_functions/multi/delaunay.py` — Delaunay pixelization across g/r, rtol=1e-2 (actual rdiff 1.4e-13 — well inside)
- `scripts/jax_likelihood_functions/multi/delaunay_mge.py` — MGE bulge + Delaunay across g/r, rtol=1e-2 (actual rdiff 3.2e-11). Enabled in `smoke_tests.txt`; the JAX-0.7 `pytype_aval_mappings` issue that disables the imaging counterpart does not bite on the multi path.
- `smoke_tests.txt` — appended 7 new entries (`lp` through `delaunay_mge`)

## Test Plan

- [x] Each new script produces `PASS: jit(log_likelihood_function) round-trip matches NumPy scalar.` standalone with `JAX_ENABLE_X64=True`.
- [x] Smoke tests pass for autogalaxy_workspace_test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)