### PR TITLE
feat: add config/build/ files (closes no_run.yaml gap)

### DIFF
--- a/config/build/copy_files.yaml
+++ b/config/build/copy_files.yaml
@@ -1,0 +1,11 @@
+# Files copied as-is into notebooks/ instead of being converted from
+# scripts/. Used by PyAutoBuild's generate.py during the pre-build step.
+#
+# Format: flat list of script paths relative to the workspace root.
+# Patterns matched by suffix — any file path ending with one of these
+# entries is treated as copy-only.
+#
+# This file overrides PyAutoBuild/autobuild/config/copy_files.yaml for
+# this workspace. Add or remove entries here, not there.
+
+[]

--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -1,0 +1,20 @@
+# Scripts to skip during automated runs (smoke tests, pre-release checks, CI).
+# Each entry is matched against script paths:
+#   - Entries with '/' do a substring match against the file path
+#   - Entries without '/' match the file stem exactly
+# Add an inline # comment to document the reason for skipping.
+#
+# SLOW-skip convention:
+#   Entries tagged `# SLOW <YYYY-MM-DD> - <reason>` mark scripts that are
+#   skipped because they exceed the per-script timeout cap. These are
+#   NOT permanent skips — every mega-run surfaces them with a loud warning
+#   banner. Fix the performance issue and remove the SLOW marker.
+#
+# NEEDS_FIX convention:
+#   Entries tagged `# NEEDS_FIX <YYYY-MM-DD> - <reason>` mark scripts that
+#   are broken and parked as a to-do list. Like SLOW-skips, these are NOT
+#   permanent skips — every mega-run surfaces them with a loud warning
+#   banner. Investigate the failure, fix the underlying bug, and remove
+#   the NEEDS_FIX marker.
+
+[]

--- a/config/build/visualise_notebooks.yaml
+++ b/config/build/visualise_notebooks.yaml
@@ -1,0 +1,10 @@
+# Notebook stems that should run when PyAutoBuild's generate / run pipeline
+# is invoked with --visualise. Used to refresh notebook output cells in main.
+#
+# Format: flat list of notebook stems (no extension, no path).
+# An empty list means no notebooks need re-visualisation in this workspace.
+#
+# This file overrides PyAutoBuild/autobuild/config/visualise_notebooks.yaml
+# for this workspace. Add or remove entries here, not there.
+
+[]


### PR DESCRIPTION
## Summary

This workspace had **no** `config/build/no_run.yaml` at all; PyAutoBuild fell through to its own keyed dict (which had an empty `autogalaxy_test: []` entry). That meant nothing was ever actually skipped via the workspace path. Now explicit (currently empty list, but workspace-owned).

Also adds `copy_files.yaml` and `visualise_notebooks.yaml` to match the migration shipping in the other workspaces under the same branch.

Companion PRs on `feature/autobuild-release-prep` across PyAutoBuild + every workspace + PyAutoPrompt.

## Test plan
- [x] PyAutoBuild's new `tests/test_workspace_config_precedence.py::test_actual_workspace_files_exist` passes for this workspace
- [x] full release-prep run picks up the new files (autogalaxy_test ran cleanly: 31 passed, 1 failed, 0 skipped)