### PR TITLE
fix: rename stale PYAUTOFIT_TEST_MODE / PYAUTO_WORKSPACE_SMALL_DATASETS in build config

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -9,8 +9,8 @@
 #   - Patterns without '/' match the file stem exactly
 
 defaults:
-  PYAUTOFIT_TEST_MODE: "2"              # 0=normal, 1=reduced iterations, 2=skip sampler (fastest)
-  PYAUTO_WORKSPACE_SMALL_DATASETS: "1"  # Cap grids/masks to 15x15, reduce MGE gaussians
+  PYAUTO_TEST_MODE: "2"              # 0=normal, 1=reduced iterations, 2=skip sampler (fastest)
+  PYAUTO_SMALL_DATASETS: "1"  # Cap grids/masks to 15x15, reduce MGE gaussians
   PYAUTO_DISABLE_JAX: "1"              # Force use_jax=False, avoid JIT compilation overhead
   PYAUTO_FAST_PLOTS: "1"               # Skip tight_layout() + critical curve/caustic overlays
   JAX_ENABLE_X64: "True"               # Enable 64-bit precision in JAX
@@ -20,8 +20,19 @@ defaults:
 overrides:
   # JAX likelihood functions test JIT compilation — need JAX enabled and full-size datasets
   - pattern: "jax_likelihood_functions/"
-    unset: [PYAUTO_WORKSPACE_SMALL_DATASETS, PYAUTO_DISABLE_JAX]
+    unset: [PYAUTO_SMALL_DATASETS, PYAUTO_DISABLE_JAX]
+  # Aggregator scripts assert grid metadata (e.g. over_sample_size_lp == 5)
+  # that depends on full-size datasets. PYAUTO_SMALL_DATASETS=1 reduces these.
+  - pattern: "aggregator/"
+    unset: [PYAUTO_SMALL_DATASETS]
+  # imaging/model_fit reads pre-committed FITS data at full resolution; the
+  # mask is built from the committed dataset shape, so PYAUTO_SMALL_DATASETS=1
+  # would yield a 15x15 array against a full-size mask.
+  - pattern: "imaging/model_fit"
+    unset: [PYAUTO_SMALL_DATASETS]
   # imaging/visualization.py asserts subplot PNG / FITS files land on disk —
-  # PYAUTO_FAST_PLOTS skips savefig and would break those assertions.
+  # PYAUTO_FAST_PLOTS skips savefig and would break those assertions. It also
+  # reads the same full-resolution dataset as imaging/model_fit, so the
+  # PYAUTO_SMALL_DATASETS cap would produce a shape mismatch with the mask.
   - pattern: "imaging/visualization"
-    unset: [PYAUTO_FAST_PLOTS]
+    unset: [PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]


### PR DESCRIPTION
## Summary
Renames stale env vars in `config/build/env_vars.yaml` to canonical names. The libraries only read `PYAUTO_TEST_MODE` and `PYAUTO_SMALL_DATASETS`, so the old names were silent no-ops — smoke runs were never actually skipping the sampler or capping datasets. After this change both flags fire as intended.

Adds three small overrides to keep scripts that depend on full-size datasets running correctly now that `PYAUTO_SMALL_DATASETS=1` actually fires (matches the existing pattern in autolens_workspace_test):
- `aggregator/` — assertions on grid metadata (e.g. `over_sample_size_lp == 5`) need full-size datasets.
- `imaging/model_fit` — reads pre-committed FITS data at full resolution; the cap would shape-mismatch the mask.
- `imaging/visualization` — same dataset; merged `PYAUTO_SMALL_DATASETS` into the existing `PYAUTO_FAST_PLOTS` unset list.

## Scripts Changed
- `config/build/env_vars.yaml` — rename `PYAUTOFIT_TEST_MODE` → `PYAUTO_TEST_MODE`, `PYAUTO_WORKSPACE_SMALL_DATASETS` → `PYAUTO_SMALL_DATASETS`; add overrides for `aggregator/`, `imaging/model_fit`, `imaging/visualization`.

Refs PyAutoLabs/autolens_workspace_test#65

## Test Plan
- [ ] Smoke tests pass with new env vars
- [ ] Verify `PYAUTO_SMALL_DATASETS=1` fires for default scripts and is correctly unset for the override patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)