### PR TITLE
fix(env): unblock modeling_visualization_jit tests in CI defaults

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -36,3 +36,9 @@ overrides:
   # PYAUTO_SMALL_DATASETS cap would produce a shape mismatch with the mask.
   - pattern: "imaging/visualization"
     unset: [PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]
+  # modeling_visualization_jit tests the JIT-cached visualization path:
+  # needs JAX enabled (Part 1 asserts log_likelihood is a jax.Array), the
+  # full-resolution mask, a real Nautilus run for Part 2, and savefig active
+  # (Part 2 asserts fit.png lands on disk).
+  - pattern: "imaging/modeling_visualization_jit"
+    unset: [PYAUTO_DISABLE_JAX, PYAUTO_SMALL_DATASETS, PYAUTO_TEST_MODE, PYAUTO_FAST_PLOTS]


### PR DESCRIPTION
## Summary

- Adds an `imaging/modeling_visualization_jit` override to `config/build/env_vars.yaml` that unsets `PYAUTO_DISABLE_JAX`, `PYAUTO_SMALL_DATASETS`, `PYAUTO_TEST_MODE`, and `PYAUTO_FAST_PLOTS` for the JIT-cached visualization tests.
- Fixes Cluster C in `PyAutoBuild/test_results/runs/2026-04-29T14-48-47Z/triage.md` (4 scripts total: 1 in autogalaxy_workspace_test, 3 in autolens_workspace_test).

## Why

The four `modeling_visualization_jit*` scripts opt into `AnalysisImaging(use_jax=True, use_jax_for_visualization=True)` and assert in Part 1:

```python
assert isinstance(fit_1.log_likelihood, jnp.ndarray)
```

Under the CI defaults, `PYAUTO_DISABLE_JAX=1` is intercepted in `PyAutoFit/autofit/non_linear/analysis/analysis.py` and silently flips `use_jax_for_visualization` off. `fit_for_visualization` then takes the numpy path and `fit_1.log_likelihood` comes back as `numpy.float64`, failing with:

```
AssertionError: expected jax.Array, got <class 'numpy.float64'>
```

`PYAUTO_SMALL_DATASETS=1` also breaks the hardcoded mask radius, `PYAUTO_TEST_MODE=2` skips the sampler that Part 2 relies on, and `PYAUTO_FAST_PLOTS=1` disables the savefig that Part 2 asserts on.

The fix mirrors the precedent in the existing `jax_likelihood_functions/` override, which unsets the same vars for the same reason.

## Scripts Changed

None. Only `config/build/env_vars.yaml`.

## Test plan

- [x] Verified `imaging/modeling_visualization_jit.py` runs end-to-end with all 4 vars unset (Part 1 PASS, Part 2 PASS, exit 0).
- [x] Verified the rectangular and delaunay variants the same way (autolens repo only).
- [x] Verified pattern only matches the four target scripts; sibling scripts (`visualization.py`, `model_fit.py`, `convolution.py`) keep their existing env settings unchanged.
