### PR TITLE
feat: scripts/jax_grad/interferometer/ — lp.py + mge.py from scratch (task 7/9)

### DIFF
--- a/scripts/jax_grad/interferometer/lp.py
+++ b/scripts/jax_grad/interferometer/lp.py
@@ -1,0 +1,95 @@
+"""
+Tests that jax.value_and_grad can compute finite, non-NaN gradients of the log-likelihood
+for an autogalaxy interferometer model with a parametric Sersic light profile. This tests
+the core JAX differentiability that enables gradient-based inference on visibility data.
+"""
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+from os import path
+
+import autofit as af
+import autogalaxy as ag
+
+dataset_path = path.join("dataset", "interferometer", "jax_test")
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not path.exists(path.join(dataset_path, "data.fits")):
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/jax_likelihood_functions/interferometer/simulator.py",
+        ],
+        check=True,
+    )
+
+real_space_mask = ag.Mask2D.circular(
+    shape_native=(256, 256),
+    pixel_scales=0.1,
+    radius=3.0,
+)
+
+dataset = ag.Interferometer.from_fits(
+    data_path=path.join(dataset_path, "data.fits"),
+    noise_map_path=path.join(dataset_path, "noise_map.fits"),
+    uv_wavelengths_path=path.join(dataset_path, "uv_wavelengths.fits"),
+    real_space_mask=real_space_mask,
+    transformer_class=ag.TransformerDFT,
+)
+
+# Single galaxy with a Sersic bulge — no lens/source split, no mass profile.
+
+bulge = af.Model(ag.lp.Sersic)
+
+galaxy = af.Model(ag.Galaxy, redshift=0.5, bulge=bulge)
+
+model = af.Collection(galaxies=af.Collection(galaxy=galaxy))
+
+print(model.info)
+
+analysis = ag.AnalysisInterferometer(dataset=dataset)
+
+from autofit.non_linear.fitness import Fitness
+
+fitness = Fitness(
+    model=model,
+    analysis=analysis,
+    fom_is_log_likelihood=True,
+    resample_figure_of_merit=-1.0e99,
+)
+
+param_vector = jnp.array(model.physical_values_from_prior_medians)
+
+# Perturb ell_comps away from (0,0) to avoid degenerate gradients at the
+# circular-profile singularity (arctan2 gradient is undefined at exactly (0,0)).
+key = jax.random.PRNGKey(0)
+perturbation = jax.random.uniform(
+    key, shape=param_vector.shape, minval=0.01, maxval=0.05
+)
+param_vector = param_vector + perturbation
+
+value, grad = jax.value_and_grad(fitness.call)(param_vector)
+
+print(f"Log likelihood = {float(value):.6f}")
+print(f"Gradient shape = {grad.shape}")
+print(f"Gradient = {np.array(grad)}")
+
+assert np.isfinite(float(value)), "Log likelihood is not finite"
+assert grad.shape == (
+    model.total_free_parameters,
+), f"Gradient shape mismatch: {grad.shape}"
+assert np.all(
+    np.isfinite(np.array(grad))
+), f"Gradient contains non-finite values: {np.array(grad)}"
+assert not np.all(np.array(grad) == 0.0), "Gradient is all zeros"
+
+print("jax_grad/interferometer/lp.py JAX gradient checks passed.")

--- a/scripts/jax_grad/interferometer/mge.py
+++ b/scripts/jax_grad/interferometer/mge.py
@@ -1,0 +1,100 @@
+"""
+Tests that jax.value_and_grad can compute finite, non-NaN gradients of the log-likelihood
+for an autogalaxy interferometer model with a Multi-Gaussian Expansion (MGE) linear basis
+light profile. This tests the core JAX differentiability that enables gradient-based
+inference on visibility data.
+"""
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+from os import path
+
+import autofit as af
+import autogalaxy as ag
+
+dataset_path = path.join("dataset", "interferometer", "jax_test")
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not path.exists(path.join(dataset_path, "data.fits")):
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/jax_likelihood_functions/interferometer/simulator.py",
+        ],
+        check=True,
+    )
+
+real_space_mask = ag.Mask2D.circular(
+    shape_native=(256, 256),
+    pixel_scales=0.1,
+    radius=3.0,
+)
+
+dataset = ag.Interferometer.from_fits(
+    data_path=path.join(dataset_path, "data.fits"),
+    noise_map_path=path.join(dataset_path, "noise_map.fits"),
+    uv_wavelengths_path=path.join(dataset_path, "uv_wavelengths.fits"),
+    real_space_mask=real_space_mask,
+    transformer_class=ag.TransformerDFT,
+)
+
+# Single galaxy with an MGE linear basis light profile — no lens/source split, no mass profile.
+
+mask_radius = 3.0
+
+bulge = ag.model_util.mge_model_from(
+    mask_radius=mask_radius, total_gaussians=20, centre_prior_is_uniform=True
+)
+
+galaxy = af.Model(ag.Galaxy, redshift=0.5, bulge=bulge)
+
+model = af.Collection(galaxies=af.Collection(galaxy=galaxy))
+
+print(model.info)
+
+analysis = ag.AnalysisInterferometer(dataset=dataset)
+
+from autofit.non_linear.fitness import Fitness
+
+fitness = Fitness(
+    model=model,
+    analysis=analysis,
+    fom_is_log_likelihood=True,
+    resample_figure_of_merit=-1.0e99,
+)
+
+param_vector = jnp.array(model.physical_values_from_prior_medians)
+
+# Perturb ell_comps away from (0,0) to avoid degenerate gradients at the
+# circular-profile singularity (arctan2 gradient is undefined at exactly (0,0)).
+key = jax.random.PRNGKey(0)
+perturbation = jax.random.uniform(
+    key, shape=param_vector.shape, minval=0.01, maxval=0.05
+)
+param_vector = param_vector + perturbation
+
+value, grad = jax.value_and_grad(fitness.call)(param_vector)
+
+print(f"Log likelihood = {float(value):.6f}")
+print(f"Gradient shape = {grad.shape}")
+print(f"Gradient = {np.array(grad)}")
+
+assert np.isfinite(float(value)), "Log likelihood is not finite"
+assert grad.shape == (
+    model.total_free_parameters,
+), f"Gradient shape mismatch: {grad.shape}"
+assert np.all(
+    np.isfinite(np.array(grad))
+), f"Gradient contains non-finite values: {np.array(grad)}"
+assert not np.all(np.array(grad) == 0.0), "Gradient is all zeros"
+
+print("jax_grad/interferometer/mge.py JAX gradient checks passed.")

--- a/smoke_tests.txt
+++ b/smoke_tests.txt
@@ -12,6 +12,8 @@ jax_likelihood_functions/imaging/delaunay.py
 # jax_likelihood_functions/imaging/delaunay_mge.py  # disabled: jax 0.7 removed jax.interpreters.xla.pytype_aval_mappings — see PyAutoPrompt/autobuild/smoke_workspace_fixes.md
 jax_grad/imaging/lp.py
 jax_grad/imaging/mge.py
+jax_grad/interferometer/lp.py
+jax_grad/interferometer/mge.py
 jax_likelihood_functions/interferometer/lp.py
 jax_likelihood_functions/interferometer/mge.py
 jax_likelihood_functions/interferometer/mge_group.py


### PR DESCRIPTION
## Summary

Create `scripts/jax_grad/interferometer/{lp.py, mge.py}` from scratch — autolens has no interferometer `jax_grad` reference today. Each script runs `jax.value_and_grad` on the autogalaxy `AnalysisInterferometer` likelihood path and asserts the gradient is finite, the shape matches `model.total_free_parameters`, and the gradient is not all-zero.

This is task 7/9 of the autogalaxy_workspace_test parity epic (#5).

## Scripts Changed

- `scripts/jax_grad/interferometer/__init__.py` — new (empty namespace marker).
- `scripts/jax_grad/interferometer/lp.py` — new. Single galaxy with a Sersic bulge on `dataset/interferometer/jax_test` with a `(256,256)` `pixel_scales=0.1` `radius=3.0` real-space mask and `TransformerDFT` (mirrors `jax_likelihood_functions/interferometer/lp.py`). Body uses `jax.value_and_grad(fitness.call)` and the four canonical assertions. Local run: 6.9s, gradient shape `(7,)`.
- `scripts/jax_grad/interferometer/mge.py` — new. Same dataset/mask/transformer; model swapped to a single-basis MGE (`mge_model_from`, 20 gaussians, `centre_prior_is_uniform=True`) on a single galaxy. Same body and assertions. Local run: 12.5s, gradient shape `(4,)`.
- `smoke_tests.txt` — appended both new scripts immediately after `jax_grad/imaging/mge.py`.

## Notes

**Layout divergence from autolens (continued).** Autolens has flat top-level `jax_grad/imaging_*.py` and no interferometer `jax_grad` scripts at all. This PR continues the subfolder convention established in PR #29 (task 6) — `jax_grad/{imaging,interferometer,multi}/` on autogalaxy. The retrofit question for autolens was raised in PR #29; suggest filing the follow-up after task 8 lands so the migration covers all three subdirectories at once.

**`lp.Sersic` vs `lp_linear.Sersic`.** Task 6 (`jax_grad/imaging/lp.py`) used `lp_linear.Sersic`. This task uses plain `lp.Sersic` to match the validated `jax_likelihood_functions/interferometer/lp.py` pattern. The interferometer + JAX inversion path differs from imaging; sticking with the proven setup.

**No env_vars.yaml change.** The `jax_grad/` substring override added in PR #29 (unset `PYAUTO_SMALL_DATASETS` + `PYAUTO_DISABLE_JAX`) already matches `jax_grad/interferometer/`.

## Test Plan

- [x] Both new scripts pass locally via `.github/scripts/run_smoke.py` with the env override applied:
  - `jax_grad/interferometer/lp.py` — exit 0 in 6.9s, grad shape `(7,)`
  - `jax_grad/interferometer/mge.py` — exit 0 in 12.5s, grad shape `(4,)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #30.