### PR TITLE
fix: register_model in visualization_jax.py to actually exercise JIT path

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -42,8 +42,14 @@ overrides:
   # PYAUTO_FAST_PLOTS skips savefig and would break those assertions. It also
   # reads the same full-resolution dataset as imaging/model_fit, so the
   # PYAUTO_SMALL_DATASETS cap would produce a shape mismatch with the mask.
-  - pattern: "imaging/visualization"
+  - pattern: "imaging/visualization.py"
     unset: [PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]
+  # imaging/visualization_jax.py exercises the jit-cached fit_for_visualization
+  # path (registered model + fit pytree). It must run with JAX enabled —
+  # PYAUTO_DISABLE_JAX=1 would silently flip use_jax flags off and the script
+  # would no-op via the NumPy fallback.
+  - pattern: "imaging/visualization_jax"
+    unset: [PYAUTO_DISABLE_JAX, PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]
   # modeling_visualization_jit tests the JIT-cached visualization path:
   # needs JAX enabled (Part 1 asserts log_likelihood is a jax.Array), the
   # full-resolution mask, a real Nautilus run for Part 2, and savefig active

--- a/scripts/imaging/visualization_jax.py
+++ b/scripts/imaging/visualization_jax.py
@@ -8,14 +8,13 @@ Single-galaxy autogalaxy port of the autolens ``visualization_jax.py`` pilot
 Goal
 ----
 Run ``VisualizerImaging.visualize`` with JAX enabled end-to-end, gated behind
-``use_jax_for_visualization`` on ``Analysis``. A parametric MGE galaxy is used
-deliberately (simplest case — no pixelization, no inversion).
-
-This is **Path C**: ``fit_from`` runs on the eager JAX path
-(``use_jax=True`` makes ``_xp`` be ``jnp``) and returns a ``FitImaging`` backed
-by ``jax.Array`` objects. Matplotlib-bound plotters materialise arrays to NumPy
-at the boundary. No ``jax.jit`` is applied to ``fit_from`` — the full-JIT path
-(Path A) is exercised by ``modeling_visualization_jit.py``.
+``use_jax_for_visualization=True`` on ``Analysis``. After PyAutoGalaxy #390
+(2026-05-08) the imaging visualizer dispatches through
+``analysis.fit_for_visualization``, which lazily wraps ``fit_from`` in
+``jax.jit``. To trace across that boundary the model and fit return type
+must be JAX pytrees, so this script enables pytree registration before
+constructing the model. Parametric MGE galaxy — simplest case (no
+pixelization, no inversion).
 
 Scope
 -----
@@ -27,7 +26,6 @@ Scope
 """
 
 import shutil
-import traceback
 from os import path
 from pathlib import Path
 from types import SimpleNamespace
@@ -41,7 +39,10 @@ conf.instance.push(
 
 import autofit as af
 import autogalaxy as ag
+from autofit.jax.pytrees import enable_pytrees, register_model
 from autogalaxy.imaging.model.visualizer import VisualizerImaging
+
+enable_pytrees()
 
 
 """
@@ -86,6 +87,8 @@ galaxy_bulge = ag.model_util.mge_model_from(
 galaxy = af.Model(ag.Galaxy, redshift=0.5, bulge=galaxy_bulge)
 model = af.Collection(galaxies=af.Collection(galaxy=galaxy))
 
+register_model(model)
+
 
 """
 __Analysis__
@@ -120,17 +123,11 @@ __Run visualize on the eager-JAX fit__
 instance = model.instance_from_prior_medians()
 
 print("Running VisualizerImaging.visualize with use_jax_for_visualization=True ...")
-try:
-    VisualizerImaging.visualize(
-        analysis=analysis,
-        paths=paths,
-        instance=instance,
-        during_analysis=False,
-    )
-    assert (image_path / "fit.png").exists(), "fit.png was not produced"
-    print("PILOT SUCCEEDED — JAX-backed visualization produced fit.png/galaxies.png.")
-except Exception:
-    print("PILOT FAILED — traceback below:")
-    print("=" * 72)
-    traceback.print_exc()
-    print("=" * 72)
+VisualizerImaging.visualize(
+    analysis=analysis,
+    paths=paths,
+    instance=instance,
+    during_analysis=False,
+)
+assert (image_path / "fit.png").exists(), "fit.png was not produced"
+print("PILOT SUCCEEDED — JAX-backed visualization produced fit.png/galaxies.png.")


### PR DESCRIPTION
## Summary

`scripts/imaging/visualization_jax.py` was silently broken under JAX since PyAutoGalaxy #390 (2026-05-08) made `VisualizerImaging.visualize` dispatch through `analysis.fit_for_visualization` (which JITs `fit_from`). Without `enable_pytrees()` + `register_model(model)`, `jax.jit(fit_from)` cannot trace the `ModelInstance` argument and raises `TypeError`. The script's `try/except` wrapper caught the failure, printed "PILOT FAILED", and exited 0 — so test runners never noticed.

This PR adds the two missing calls, drops the swallowed-exception pattern so future regressions fail loud, and splits the `imaging/visualization` env_vars override into a NumPy-only entry and a JAX-only entry that unsets `PYAUTO_DISABLE_JAX`, mirroring the existing `imaging/modeling_visualization_jit` override.

Lead PR (closes the tracking issue): https://github.com/PyAutoLabs/autolens_workspace_test/pull/85

## Scripts Changed

- `scripts/imaging/visualization_jax.py` — add `enable_pytrees()` + `register_model(model)`; drop `try/except` wrapper; update docstring to reflect the Path-A (jit-traced) intent
- `config/build/env_vars.yaml` — split `imaging/visualization` override; add `imaging/visualization_jax` entry that unsets `PYAUTO_DISABLE_JAX`

## Test Plan

- [x] `python scripts/imaging/visualization_jax.py` (with JAX enabled) — `PILOT SUCCEEDED — JAX-backed visualization produced fit.png/galaxies.png.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)