### PR TITLE
feat: add numpy ellipse jax_likelihood reference scripts

### DIFF
--- a/scripts/jax_likelihood_functions/ellipse/fit.py
+++ b/scripts/jax_likelihood_functions/ellipse/fit.py
@@ -1,0 +1,106 @@
+"""
+Numpy Likelihood: Ellipse Fit
+==============================
+
+Step 2 of ``z_features/ellipse_fitting_jax.md``.
+
+Prints the numpy-path reference numbers that prompt 7 will JIT-assert against
+to ``rtol=1e-4``. Run this script to capture the baseline log-likelihood,
+chi-squared, noise-normalisation, and figure-of-merit values for a single
+ellipse fit to the simulated dataset.
+"""
+
+from os import path
+
+import autofit as af
+import autogalaxy as ag
+
+
+dataset_path = path.join("dataset", "ellipse", "jax_test")
+
+if not path.exists(path.join(dataset_path, "data.fits")):
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/jax_likelihood_functions/ellipse/simulator.py"],
+        check=True,
+    )
+
+dataset = ag.Imaging.from_fits(
+    data_path=path.join(dataset_path, "data.fits"),
+    psf_path=path.join(dataset_path, "psf.fits"),
+    noise_map_path=path.join(dataset_path, "noise_map.fits"),
+    pixel_scales=0.2,
+)
+
+"""
+__Mask__
+"""
+mask = ag.Mask2D.circular(
+    shape_native=dataset.shape_native,
+    pixel_scales=dataset.pixel_scales,
+    radius=3.0,
+)
+
+dataset = dataset.apply_mask(mask=mask)
+
+"""
+__Model__
+"""
+ellipse = af.Model(ag.Ellipse)
+
+ellipse.centre.centre_0 = af.UniformPrior(lower_limit=-0.1, upper_limit=0.1)
+ellipse.centre.centre_1 = af.UniformPrior(lower_limit=-0.1, upper_limit=0.1)
+
+ellipse.ell_comps.ell_comps_0 = af.UniformPrior(lower_limit=-0.6, upper_limit=0.6)
+ellipse.ell_comps.ell_comps_1 = af.UniformPrior(lower_limit=-0.6, upper_limit=0.6)
+
+ellipse.major_axis = 0.5
+
+model = af.Collection(ellipses=[ellipse])
+
+print(model.info)
+
+"""
+__Analysis (NumPy Path)__
+"""
+analysis = ag.AnalysisEllipse(dataset=dataset)  # use_jax defaults to False
+
+instance = model.instance_from_prior_medians()
+
+fit_list = analysis.fit_list_from(instance=instance)
+
+"""
+__Reference Numbers__
+"""
+for i, fit in enumerate(fit_list):
+    print(f"Ellipse {i}:")
+    print(f"  log_likelihood     = {fit.log_likelihood:.8f}")
+    print(f"  chi_squared        = {fit.chi_squared:.8f}")
+    print(f"  noise_normalization= {fit.noise_normalization:.8f}")
+    print(f"  figure_of_merit    = {fit.figure_of_merit:.8f}")
+
+total_log_likelihood = sum(fit.log_likelihood for fit in fit_list)
+total_figure_of_merit = sum(fit.figure_of_merit for fit in fit_list)
+
+print(f"Aggregate:")
+print(f"  total_log_likelihood = {total_log_likelihood:.8f}")
+print(f"  total_figure_of_merit= {total_figure_of_merit:.8f}")
+
+"""
+__TODO(7_analysis_ellipse_jax.md)__
+
+Once `AnalysisEllipse` gains the `use_jax: bool = True` flag and a
+`_register_fit_ellipse_pytrees()` helper, this script should additionally:
+
+    analysis_jit = ag.AnalysisEllipse(dataset=dataset, use_jax=True)
+    fit_jit_fn = jax.jit(analysis_jit.fit_from)
+    fit_jit = fit_jit_fn(instance)
+
+    np.testing.assert_allclose(
+        float(fit_jit.log_likelihood),
+        total_log_likelihood,
+        rtol=1e-4,
+    )
+"""

--- a/scripts/jax_likelihood_functions/ellipse/multipoles.py
+++ b/scripts/jax_likelihood_functions/ellipse/multipoles.py
@@ -1,0 +1,118 @@
+"""
+Numpy Likelihood: Ellipse Fit With Multipole
+=============================================
+
+Step 2 of ``z_features/ellipse_fitting_jax.md`` — multipole variant.
+
+Locks the multipole code path as a numpy-baseline. The JAX-incompatible
+``while`` loops in ``EllipseMultipole.get_shape_angle`` are handled by
+prompt 5; this script establishes the reference numbers that prompt 7 will
+JIT-assert against to ``rtol=1e-4``.
+
+Prints the numpy-path log-likelihood, chi-squared, noise-normalisation, and
+figure-of-merit values for a single ellipse + m=4 multipole fit to the
+simulated dataset.
+"""
+
+from os import path
+
+import autofit as af
+import autogalaxy as ag
+
+
+dataset_path = path.join("dataset", "ellipse", "jax_test")
+
+if not path.exists(path.join(dataset_path, "data.fits")):
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/jax_likelihood_functions/ellipse/simulator.py"],
+        check=True,
+    )
+
+dataset = ag.Imaging.from_fits(
+    data_path=path.join(dataset_path, "data.fits"),
+    psf_path=path.join(dataset_path, "psf.fits"),
+    noise_map_path=path.join(dataset_path, "noise_map.fits"),
+    pixel_scales=0.2,
+)
+
+"""
+__Mask__
+"""
+mask = ag.Mask2D.circular(
+    shape_native=dataset.shape_native,
+    pixel_scales=dataset.pixel_scales,
+    radius=3.0,
+)
+
+dataset = dataset.apply_mask(mask=mask)
+
+"""
+__Model__
+"""
+ellipse = af.Model(ag.Ellipse)
+
+ellipse.centre.centre_0 = af.UniformPrior(lower_limit=-0.1, upper_limit=0.1)
+ellipse.centre.centre_1 = af.UniformPrior(lower_limit=-0.1, upper_limit=0.1)
+
+ellipse.ell_comps.ell_comps_0 = af.UniformPrior(lower_limit=-0.6, upper_limit=0.6)
+ellipse.ell_comps.ell_comps_1 = af.UniformPrior(lower_limit=-0.6, upper_limit=0.6)
+
+ellipse.major_axis = 0.5
+
+multipole = af.Model(ag.EllipseMultipole)
+multipole.m = 4
+multipole.multipole_comps.multipole_comps_0 = 0.05
+multipole.multipole_comps.multipole_comps_1 = 0.0
+
+model = af.Collection(
+    ellipses=[ellipse],
+    multipoles=[[multipole]],
+)
+
+print(model.info)
+
+"""
+__Analysis (NumPy Path)__
+"""
+analysis = ag.AnalysisEllipse(dataset=dataset)  # use_jax defaults to False
+
+instance = model.instance_from_prior_medians()
+
+fit_list = analysis.fit_list_from(instance=instance)
+
+"""
+__Reference Numbers__
+"""
+for i, fit in enumerate(fit_list):
+    print(f"Ellipse {i}:")
+    print(f"  log_likelihood     = {fit.log_likelihood:.8f}")
+    print(f"  chi_squared        = {fit.chi_squared:.8f}")
+    print(f"  noise_normalization= {fit.noise_normalization:.8f}")
+    print(f"  figure_of_merit    = {fit.figure_of_merit:.8f}")
+
+total_log_likelihood = sum(fit.log_likelihood for fit in fit_list)
+total_figure_of_merit = sum(fit.figure_of_merit for fit in fit_list)
+
+print(f"Aggregate:")
+print(f"  total_log_likelihood = {total_log_likelihood:.8f}")
+print(f"  total_figure_of_merit= {total_figure_of_merit:.8f}")
+
+"""
+__TODO(7_analysis_ellipse_jax.md)__
+
+Once `AnalysisEllipse` gains the `use_jax: bool = True` flag and a
+`_register_fit_ellipse_pytrees()` helper, this script should additionally:
+
+    analysis_jit = ag.AnalysisEllipse(dataset=dataset, use_jax=True)
+    fit_jit_fn = jax.jit(analysis_jit.fit_from)
+    fit_jit = fit_jit_fn(instance)
+
+    np.testing.assert_allclose(
+        float(fit_jit.log_likelihood),
+        total_log_likelihood,
+        rtol=1e-4,
+    )
+"""

--- a/scripts/jax_likelihood_functions/ellipse/simulator.py
+++ b/scripts/jax_likelihood_functions/ellipse/simulator.py
@@ -1,0 +1,74 @@
+"""
+Simulator: JAX Ellipse Test Dataset
+====================================
+
+Simulates a small `Imaging` dataset consumed by every script in
+``scripts/jax_likelihood_functions/ellipse/``.
+
+A single galaxy with a Sersic bulge is imaged at moderate signal-to-noise.
+No lens / mass / source plane — this is a single-plane autogalaxy dataset
+designed to exercise the JAX ellipse-fitting likelihood path.
+
+Note: ellipse fitting does not use the PSF during the fit, but the PSF is
+written to ``psf.fits`` to maintain ``Imaging.from_fits`` symmetry with the
+other ``jax_likelihood_functions`` simulators.
+
+Output files (under ``dataset/ellipse/jax_test/``):
+
+- ``data.fits`` — the simulated noisy image
+- ``psf.fits`` — the Gaussian PSF kernel used during simulation
+- ``noise_map.fits`` — per-pixel 1-sigma noise map
+- ``galaxies.json`` — the exact ``Galaxies`` used, for reproducibility
+"""
+
+from pathlib import Path
+
+import autogalaxy as ag
+import autogalaxy.plot as aplt
+
+
+dataset_path = Path("dataset", "ellipse", "jax_test")
+
+grid = ag.Grid2D.uniform(shape_native=(50, 50), pixel_scales=0.2)
+
+psf = ag.Convolver.from_gaussian(
+    shape_native=(11, 11), sigma=0.1, pixel_scales=grid.pixel_scales, normalize=True
+)
+
+simulator = ag.SimulatorImaging(
+    exposure_time=300.0,
+    psf=psf,
+    background_sky_level=1.0,
+    add_poisson_noise_to_data=True,
+    noise_seed=1,
+)
+
+galaxy = ag.Galaxy(
+    redshift=0.5,
+    bulge=ag.lp.Sersic(
+        centre=(0.0, 0.0),
+        ell_comps=ag.convert.ell_comps_from(axis_ratio=0.7, angle=45.0),
+        intensity=4.0,
+        effective_radius=0.6,
+        sersic_index=3.0,
+    ),
+)
+
+galaxies = ag.Galaxies(galaxies=[galaxy])
+
+dataset = simulator.via_galaxies_from(galaxies=galaxies, grid=grid)
+
+aplt.fits_imaging(
+    dataset=dataset,
+    data_path=dataset_path / "data.fits",
+    psf_path=dataset_path / "psf.fits",
+    noise_map_path=dataset_path / "noise_map.fits",
+    overwrite=True,
+)
+
+ag.output_to_json(
+    obj=galaxies,
+    file_path=Path(dataset_path, "galaxies.json"),
+)
+
+print("Dataset written to", dataset_path)


### PR DESCRIPTION
## Summary

Add the numpy-baseline reference scripts under `scripts/jax_likelihood_functions/ellipse/` that lock in the reference numbers for ellipse fitting before the JAX path lands. Step 2 of 7 in the `ellipse_fitting_jax` feature decomposition (`PyAutoPrompt/z_features/ellipse_fitting_jax.md`).

Each script auto-simulates the dataset on first run, builds a fixed-parameter ellipse model (plus multipole for `multipoles.py`), and prints every component of every `FitEllipse` produced by `AnalysisEllipse.fit_list_from(...)`. Prompt 7 of the feature will JIT-wrap `analysis.fit_from` and assert against these numbers with `np.testing.assert_allclose(rtol=1e-4)`.

Numpy-only — no `import jax` anywhere in the new scripts. Both `fit.py` and `multipoles.py` are deterministic across runs (verified by diff-comparison of two runs).

Reference numbers captured at the prior medians of the model:

| Component | fit.py | multipoles.py |
|-----------|--------|---------------|
| log_likelihood | -382.22660947 | -725.51150750 |
| chi_squared | 764.45321894 | 1451.02301500 |
| noise_normalization | -27.02295060 | -26.84755137 |
| figure_of_merit | -368.71513417 | -712.08773182 |

Issue #41.

## Scripts Changed
- `scripts/jax_likelihood_functions/ellipse/__init__.py` — new empty package marker.
- `scripts/jax_likelihood_functions/ellipse/simulator.py` — new; simulates a 50×50 single-Sersic-galaxy `Imaging` dataset (`noise_seed=1`) into `dataset/ellipse/jax_test/`. Independent of `imaging/simulator.py` so the ellipse reference numbers don't drift with future imaging-side retuning.
- `scripts/jax_likelihood_functions/ellipse/fit.py` — new; single-ellipse numpy reference, prints the four FOM components per fit, ends with a `# TODO(7_analysis_ellipse_jax.md)` placeholder block.
- `scripts/jax_likelihood_functions/ellipse/multipoles.py` — new; same shape but with `EllipseMultipole(m=4, multipole_comps=(0.05, 0.0))` per ellipse. Uses the `multipoles=[[multipole]]` list-of-lists composition shape so `AnalysisEllipse.fit_list_from`'s `instance.multipoles[i]` access works correctly.

## Test Plan
- [ ] Smoke tests pass for autogalaxy_workspace_test
- [ ] Both `fit.py` and `multipoles.py` re-runs produce byte-identical reference numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)