### PR TITLE
feat: add quantity JAX visualization scripts (Phase 1C-extension)

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -63,3 +63,8 @@ overrides:
   # interferometer/modeling_visualization_jit — live Nautilus + JIT path.
   - pattern: "interferometer/modeling_visualization_jit"
     unset: [PYAUTO_DISABLE_JAX, PYAUTO_SMALL_DATASETS, PYAUTO_TEST_MODE, PYAUTO_FAST_PLOTS]
+  # quantity/visualization_jax exercises the jit-cached
+  # fit_for_visualization path on the quantity side (wired in
+  # PyAutoGalaxy #404).
+  - pattern: "quantity/visualization_jax"
+    unset: [PYAUTO_DISABLE_JAX, PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]

--- a/scripts/quantity/visualization.py
+++ b/scripts/quantity/visualization.py
@@ -1,0 +1,108 @@
+"""
+Visualization: Quantity Analysis (autogalaxy)
+=============================================
+
+Tests that ``VisualizerQuantity.visualize`` outputs the expected ``fit.png``
+to disk on the NumPy (non-JAX) code path.
+
+Dataset is synthesized inline from the convergence of a known ``IsothermalSph``
+mass profile so that the model can recover a meaningful signal.  No pre-canned
+FITS fixture is required.
+"""
+
+import shutil
+from os import path
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+
+import autofit as af
+import autogalaxy as ag
+from autogalaxy.quantity.dataset_quantity import DatasetQuantity
+from autogalaxy.quantity.model.visualizer import VisualizerQuantity
+
+
+"""
+__Dataset__
+
+Synthesize a convergence map from a known IsothermalSph mass profile.
+The mask covers a 30x30 field at 0.2 arcsec/pixel; the convergence of
+einstein_radius=1.5 gives a signal strong enough for a meaningful fit.
+"""
+mask = ag.Mask2D.circular(
+    shape_native=(30, 30),
+    pixel_scales=0.2,
+    radius=2.5,
+)
+
+grid = ag.Grid2D.from_mask(mask=mask)
+
+target_convergence = ag.mp.IsothermalSph(
+    centre=(0.0, 0.0), einstein_radius=1.5
+).convergence_2d_from(grid=grid)
+
+data = target_convergence
+noise_map = ag.Array2D(
+    values=np.ones(target_convergence.shape_native) * 0.05,
+    mask=mask,
+)
+
+dataset = DatasetQuantity(data=data, noise_map=noise_map)
+
+
+"""
+__Model__
+
+Single galaxy with an IsothermalSph mass profile.  Tight priors so the
+model can recover the known einstein_radius=1.5 quickly.
+"""
+mass = af.Model(ag.mp.IsothermalSph)
+mass.centre.centre_0 = af.UniformPrior(lower_limit=-0.1, upper_limit=0.1)
+mass.centre.centre_1 = af.UniformPrior(lower_limit=-0.1, upper_limit=0.1)
+mass.einstein_radius = af.UniformPrior(lower_limit=1.3, upper_limit=1.7)
+
+galaxy = af.Model(ag.Galaxy, redshift=0.5, mass=mass)
+model = af.Collection(galaxies=af.Collection(galaxy=galaxy))
+
+
+"""
+__Analysis__
+
+Explicit NumPy path (use_jax=False).  This exercises the ``VisualizerQuantity``
+call chain without JIT compilation, confirming the baseline doesn't regress.
+"""
+analysis = ag.AnalysisQuantity(
+    dataset=dataset,
+    func_str="convergence_2d_from",
+    use_jax=False,
+)
+
+
+"""
+__Paths__
+"""
+image_path = Path("scripts") / "quantity" / "images" / "visualization"
+if image_path.exists():
+    shutil.rmtree(image_path)
+image_path.mkdir(parents=True)
+output_path = image_path / "output"
+output_path.mkdir(parents=True)
+paths = SimpleNamespace(image_path=image_path, output_path=output_path)
+
+
+"""
+__Visualize__
+"""
+instance = model.instance_from_prior_medians()
+
+print("Running VisualizerQuantity.visualize (NumPy path) ...")
+VisualizerQuantity.visualize(
+    analysis=analysis,
+    paths=paths,
+    instance=instance,
+    during_analysis=False,
+)
+
+assert (image_path / "fit.png").exists(), "fit.png was not produced"
+print("NumPy quantity visualization produced fit.png.")

--- a/scripts/quantity/visualization_jax.py
+++ b/scripts/quantity/visualization_jax.py
@@ -1,0 +1,124 @@
+"""
+Visualization JAX Pilot: Quantity Analysis (autogalaxy)
+=======================================================
+
+Tests that ``VisualizerQuantity.visualize`` with ``use_jax_for_visualization=True``
+dispatches through the JIT-cached ``fit_for_visualization`` path wired in
+PyAutoGalaxy #404.
+
+Dataset is synthesized inline from the convergence of a known ``IsothermalSph``
+mass profile so that the model can recover a meaningful signal.  No pre-canned
+FITS fixture is required.
+
+Scope
+-----
+- Parametric single-galaxy model with ``IsothermalSph`` mass profile.
+- Calls ``VisualizerQuantity.visualize`` only (not ``visualize_before_fit``).
+- Synthesizes the dataset inline — no external FITS files.
+- ``use_jax_for_visualization=True`` exercises the JIT path added in PR #404.
+"""
+
+import shutil
+from os import path
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+
+import autofit as af
+import autogalaxy as ag
+from autofit.jax.pytrees import enable_pytrees, register_model
+from autogalaxy.quantity.dataset_quantity import DatasetQuantity
+from autogalaxy.quantity.model.visualizer import VisualizerQuantity
+
+enable_pytrees()
+
+
+"""
+__Dataset__
+
+Synthesize a convergence map from a known IsothermalSph mass profile.
+The mask covers a 30x30 field at 0.2 arcsec/pixel; the convergence of
+einstein_radius=1.5 gives a signal strong enough for a meaningful fit.
+"""
+mask = ag.Mask2D.circular(
+    shape_native=(30, 30),
+    pixel_scales=0.2,
+    radius=2.5,
+)
+
+grid = ag.Grid2D.from_mask(mask=mask)
+
+target_convergence = ag.mp.IsothermalSph(
+    centre=(0.0, 0.0), einstein_radius=1.5
+).convergence_2d_from(grid=grid)
+
+data = target_convergence
+noise_map = ag.Array2D(
+    values=np.ones(target_convergence.shape_native) * 0.05,
+    mask=mask,
+)
+
+dataset = DatasetQuantity(data=data, noise_map=noise_map)
+
+
+"""
+__Model__
+
+Single galaxy with an IsothermalSph mass profile.  Tight priors so the
+model can recover the known einstein_radius=1.5 quickly.
+"""
+mass = af.Model(ag.mp.IsothermalSph)
+mass.centre.centre_0 = af.UniformPrior(lower_limit=-0.1, upper_limit=0.1)
+mass.centre.centre_1 = af.UniformPrior(lower_limit=-0.1, upper_limit=0.1)
+mass.einstein_radius = af.UniformPrior(lower_limit=1.3, upper_limit=1.7)
+
+galaxy = af.Model(ag.Galaxy, redshift=0.5, mass=mass)
+model = af.Collection(galaxies=af.Collection(galaxy=galaxy))
+
+register_model(model)
+
+
+"""
+__Analysis__
+
+``use_jax=True`` turns on the JAX ``_xp`` path; ``use_jax_for_visualization=True``
+tells the search-level visualization path to wrap ``fit_from`` in ``jax.jit``
+via the ``Analysis.fit_for_visualization`` helper (wired in PyAutoGalaxy #404).
+"""
+analysis = ag.AnalysisQuantity(
+    dataset=dataset,
+    func_str="convergence_2d_from",
+    use_jax=True,
+    use_jax_for_visualization=True,
+    title_prefix="JAX_PILOT",
+)
+
+
+"""
+__Paths__
+"""
+image_path = Path("scripts") / "quantity" / "images" / "visualization_jax"
+if image_path.exists():
+    shutil.rmtree(image_path)
+image_path.mkdir(parents=True)
+output_path = image_path / "output"
+output_path.mkdir(parents=True)
+paths = SimpleNamespace(image_path=image_path, output_path=output_path)
+
+
+"""
+__Run visualize on the eager-JAX fit__
+"""
+instance = model.instance_from_prior_medians()
+
+print("Running VisualizerQuantity.visualize with use_jax_for_visualization=True ...")
+VisualizerQuantity.visualize(
+    analysis=analysis,
+    paths=paths,
+    instance=instance,
+    during_analysis=False,
+)
+
+assert (image_path / "fit.png").exists(), "fit.png was not produced"
+print("PILOT SUCCEEDED — JAX-backed quantity visualization produced fit.png.")


### PR DESCRIPTION
## Summary

Phase 1C-extension. Follow-up to PyAutoGalaxy #404 (wired `VisualizerQuantity` through `fit_for_visualization`) and #405 (registered `DatasetModel` pytree). With both library pieces in place, `use_jax_for_visualization=True` on `ag.AnalysisQuantity` actually fires the JIT-cached visualization path — these two scripts exercise it end-to-end.

## Scripts Changed

- `scripts/quantity/visualization.py` (NEW) — NumPy baseline. Synthesizes a target convergence map from a known `IsothermalSph` mass profile and fits with a matching parametric model. Calls `VisualizerQuantity.visualize` directly; asserts `fit.png` lands. No external FITS fixture needed.
- `scripts/quantity/visualization_jax.py` (NEW) — JAX path. Adds `enable_pytrees()` + `register_model(model)`, constructs `ag.AnalysisQuantity(use_jax=True, use_jax_for_visualization=True, ...)`, calls `VisualizerQuantity.visualize` directly (no `try/except`). Same dataset + model as the NumPy baseline.
- `config/build/env_vars.yaml` — add `quantity/visualization_jax` override (unset `PYAUTO_DISABLE_JAX, PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS`), mirroring the imaging and interferometer analogues.

No `modeling_visualization_jit.py` — per the Phase 1C prompt, quantity fits don't typically use Nautilus quick-update visualization (one-shot fitting rather than the iterative-convergence pattern of imaging).

## Test Plan

- [x] `python scripts/quantity/visualization.py` — `NumPy quantity visualization produced fit.png.`
- [x] `JAX_ENABLE_X64=True python scripts/quantity/visualization_jax.py` — `PILOT SUCCEEDED — JAX-backed quantity visualization produced fit.png.` (verified with the library fixes from #404 + #405 in place — no workspace-side workaround needed)

## Roadmap context

Closes the autogalaxy quantity gap in Phase 1C. With this PR, the JAX visualization coverage matrix for autogalaxy_workspace_test is:

| Dataset | NumPy | JAX | jit (Nautilus) |
|---|---|---|---|
| imaging | ✓ | ✓ | ✓ |
| interferometer | ✓ | ✓ | ✓ |
| quantity | ✓ | ✓ | n/a (one-shot) |
| ellipse | ✓ (pre-existing) | — | n/a |

Only ellipse JAX coverage remains — blocked on the autofit `fit_for_visualization` contract design for list-returning analyses (`AnalysisEllipse.fit_list_from` returns `List[FitEllipse]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)