### PR TITLE
feat: JAX JIT round-trip + vmap blocks in jax_likelihood_functions/ellipse

### DIFF
--- a/scripts/ellipse/visualization.py
+++ b/scripts/ellipse/visualization.py
@@ -230,7 +230,9 @@ for scenario_name, dataset, model in scenarios:
     sub_output.mkdir(parents=True)
     sub_paths = SimpleNamespace(image_path=sub_path, output_path=sub_output)
 
-    analysis = ag.AnalysisEllipse(dataset=dataset, title_prefix=scenario_name.upper())
+    analysis = ag.AnalysisEllipse(
+        dataset=dataset, title_prefix=scenario_name.upper(), use_jax=False
+    )
     instance = model.instance_from_prior_medians()
 
     _t0 = time.perf_counter()

--- a/scripts/jax_likelihood_functions/ellipse/fit.py
+++ b/scripts/jax_likelihood_functions/ellipse/fit.py
@@ -12,6 +12,8 @@ ellipse fit to the simulated dataset.
 
 from os import path
 
+import numpy as np
+
 import autofit as af
 import autogalaxy as ag
 
@@ -65,7 +67,7 @@ print(model.info)
 """
 __Analysis (NumPy Path)__
 """
-analysis = ag.AnalysisEllipse(dataset=dataset)  # use_jax defaults to False
+analysis = ag.AnalysisEllipse(dataset=dataset, use_jax=False)
 
 instance = model.instance_from_prior_medians()
 
@@ -89,18 +91,59 @@ print(f"  total_log_likelihood = {total_log_likelihood:.8f}")
 print(f"  total_figure_of_merit= {total_figure_of_merit:.8f}")
 
 """
-__TODO(7_analysis_ellipse_jax.md)__
+__vmap Path__
 
-Once `AnalysisEllipse` gains the `use_jax: bool = True` flag and a
-`_register_fit_ellipse_pytrees()` helper, this script should additionally:
-
-    analysis_jit = ag.AnalysisEllipse(dataset=dataset, use_jax=True)
-    fit_jit_fn = jax.jit(analysis_jit.fit_from)
-    fit_jit = fit_jit_fn(instance)
-
-    np.testing.assert_allclose(
-        float(fit_jit.log_likelihood),
-        total_log_likelihood,
-        rtol=1e-4,
-    )
+Wrap the autofit ``Fitness`` in ``jax.vmap`` and evaluate a batch of parameter
+vectors. This exercises the full likelihood pipeline through JIT.
 """
+import time
+import jax
+import jax.numpy as jnp
+from autofit.non_linear.fitness import Fitness
+
+batch_size = 50
+
+fitness = Fitness(
+    model=model,
+    analysis=ag.AnalysisEllipse(dataset=dataset, use_jax=True),
+    fom_is_log_likelihood=True,
+    resample_figure_of_merit=-1.0e99,
+)
+
+parameters = np.zeros((batch_size, model.total_free_parameters))
+for i in range(batch_size):
+    parameters[i, :] = model.physical_values_from_prior_medians
+parameters = jnp.array(parameters)
+
+start = time.time()
+result = fitness._vmap(parameters)
+print(result)
+print("JAX Time To VMAP + JIT Function:", time.time() - start)
+
+start = time.time()
+result = fitness._vmap(parameters)
+print("JAX Time Taken using VMAP:", time.time() - start)
+print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
+
+"""
+__JIT fit_from round-trip__
+
+Assert that ``jax.jit(analysis.fit_from)(instance)`` returns a ``FitEllipseSummed``
+with a ``jax.Array`` ``log_likelihood`` matching the NumPy-path scalar.
+"""
+from autofit.jax.pytrees import enable_pytrees, register_model
+
+enable_pytrees()
+register_model(model)
+
+analysis_jit = ag.AnalysisEllipse(dataset=dataset, use_jax=True)
+fit_jit_fn = jax.jit(analysis_jit.fit_from)
+fit = fit_jit_fn(instance)
+
+print("JIT fit.log_likelihood:", fit.log_likelihood)
+assert isinstance(fit.log_likelihood, jnp.ndarray), \
+    f"expected jax.Array, got {type(fit.log_likelihood)}"
+np.testing.assert_allclose(
+    float(fit.log_likelihood), total_log_likelihood, rtol=1e-4
+)
+print("PASS: jit(fit_from) round-trip matches NumPy scalar.")

--- a/scripts/jax_likelihood_functions/ellipse/multipoles.py
+++ b/scripts/jax_likelihood_functions/ellipse/multipoles.py
@@ -16,6 +16,8 @@ simulated dataset.
 
 from os import path
 
+import numpy as np
+
 import autofit as af
 import autogalaxy as ag
 
@@ -77,7 +79,7 @@ print(model.info)
 """
 __Analysis (NumPy Path)__
 """
-analysis = ag.AnalysisEllipse(dataset=dataset)  # use_jax defaults to False
+analysis = ag.AnalysisEllipse(dataset=dataset, use_jax=False)
 
 instance = model.instance_from_prior_medians()
 
@@ -101,18 +103,59 @@ print(f"  total_log_likelihood = {total_log_likelihood:.8f}")
 print(f"  total_figure_of_merit= {total_figure_of_merit:.8f}")
 
 """
-__TODO(7_analysis_ellipse_jax.md)__
+__vmap Path__
 
-Once `AnalysisEllipse` gains the `use_jax: bool = True` flag and a
-`_register_fit_ellipse_pytrees()` helper, this script should additionally:
-
-    analysis_jit = ag.AnalysisEllipse(dataset=dataset, use_jax=True)
-    fit_jit_fn = jax.jit(analysis_jit.fit_from)
-    fit_jit = fit_jit_fn(instance)
-
-    np.testing.assert_allclose(
-        float(fit_jit.log_likelihood),
-        total_log_likelihood,
-        rtol=1e-4,
-    )
+Wrap the autofit ``Fitness`` in ``jax.vmap`` and evaluate a batch of parameter
+vectors. This exercises the full likelihood pipeline through JIT.
 """
+import time
+import jax
+import jax.numpy as jnp
+from autofit.non_linear.fitness import Fitness
+
+batch_size = 50
+
+fitness = Fitness(
+    model=model,
+    analysis=ag.AnalysisEllipse(dataset=dataset, use_jax=True),
+    fom_is_log_likelihood=True,
+    resample_figure_of_merit=-1.0e99,
+)
+
+parameters = np.zeros((batch_size, model.total_free_parameters))
+for i in range(batch_size):
+    parameters[i, :] = model.physical_values_from_prior_medians
+parameters = jnp.array(parameters)
+
+start = time.time()
+result = fitness._vmap(parameters)
+print(result)
+print("JAX Time To VMAP + JIT Function:", time.time() - start)
+
+start = time.time()
+result = fitness._vmap(parameters)
+print("JAX Time Taken using VMAP:", time.time() - start)
+print("JAX Time Taken per Likelihood:", (time.time() - start) / batch_size)
+
+"""
+__JIT fit_from round-trip__
+
+Assert that ``jax.jit(analysis.fit_from)(instance)`` returns a ``FitEllipseSummed``
+with a ``jax.Array`` ``log_likelihood`` matching the NumPy-path scalar.
+"""
+from autofit.jax.pytrees import enable_pytrees, register_model
+
+enable_pytrees()
+register_model(model)
+
+analysis_jit = ag.AnalysisEllipse(dataset=dataset, use_jax=True)
+fit_jit_fn = jax.jit(analysis_jit.fit_from)
+fit = fit_jit_fn(instance)
+
+print("JIT fit.log_likelihood:", fit.log_likelihood)
+assert isinstance(fit.log_likelihood, jnp.ndarray), \
+    f"expected jax.Array, got {type(fit.log_likelihood)}"
+np.testing.assert_allclose(
+    float(fit.log_likelihood), total_log_likelihood, rtol=1e-4
+)
+print("PASS: jit(fit_from) round-trip matches NumPy scalar.")


### PR DESCRIPTION
## Summary

Ships the workspace half of `analysis-ellipse-jax` — the keystone (step 7 of 7) in the `ellipse_fitting_jax` feature decomposition. Flips the prompt-2 TODO placeholders in `scripts/jax_likelihood_functions/ellipse/{fit,multipoles}.py` into real JIT round-trip + `fitness._vmap` assertions modelled on `scripts/jax_likelihood_functions/imaging/lp.py`. Updates `scripts/ellipse/visualization.py` to pass `use_jax=False` so the visualizer's matplotlib plotters keep numpy arrays under the new library default (`use_jax=True`).

Both scripts now print the prompt-2 numpy reference numbers (byte-stable), exercise `jax.vmap` batched evaluation through autofit's `Fitness`, and assert `np.testing.assert_allclose(float(fit.log_likelihood), total_log_likelihood, rtol=1e-4)` for the `jax.jit(analysis.fit_from)(instance)` round-trip. Both PASS on the worktree.

## Scripts Changed

- `scripts/ellipse/visualization.py` — `AnalysisEllipse(dataset=..., title_prefix=...)` → `AnalysisEllipse(dataset=..., title_prefix=..., use_jax=False)`. The visualizer feeds matplotlib which can't accept JAX tracers under the new library default.
- `scripts/jax_likelihood_functions/ellipse/fit.py` — explicit `use_jax=False` on the numpy-reference `AnalysisEllipse`; removed the stale `TODO` docstring block; added `__vmap Path__` block (50-batch evaluation via `Fitness._vmap`) and `__JIT fit_from round-trip__` block (`isinstance(fit.log_likelihood, jnp.ndarray)` + `assert_allclose(rtol=1e-4)` against `total_log_likelihood = -382.22660947`).
- `scripts/jax_likelihood_functions/ellipse/multipoles.py` — same treatment with multipole-perturbed reference `total_log_likelihood = -725.51150750`.

## Upstream PR

https://github.com/PyAutoLabs/PyAutoGalaxy/pull/412

## Test Plan

- [ ] Smoke tests pass for autogalaxy_workspace_test (and adjacent workspaces, since the suite runs all 6)
- [ ] `python scripts/jax_likelihood_functions/ellipse/fit.py` prints `PASS: jit(fit_from) round-trip matches NumPy scalar.`
- [ ] `python scripts/jax_likelihood_functions/ellipse/multipoles.py` same
- [ ] Library-first merge gate: PR #412 must merge before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)