### PR TITLE
config(env_vars): add overrides for ellipse/interferometer/quantity visualization

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -6,7 +6,10 @@
 #
 # Pattern convention (same as no_run.yaml):
 #   - Patterns containing '/' do a substring match against the file path
-#   - Patterns without '/' match the file stem exactly
+#     including extension (so patterns may end in `.py` to anchor against
+#     the script form, e.g. `imaging/visualization.py` matches only the
+#     `.py` script, not `imaging/visualization_jax.py`).
+#   - Patterns without '/' match the file stem exactly.
 
 defaults:
   PYAUTO_TEST_MODE: "2"              # 0=normal, 1=reduced iterations, 2=skip sampler (fastest)
@@ -50,12 +53,25 @@ overrides:
   # would no-op via the NumPy fallback.
   - pattern: "imaging/visualization_jax"
     unset: [PYAUTO_DISABLE_JAX, PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]
+  # ellipse/visualization.py asserts subplot PNG / FITS files land on disk
+  # (same intent as imaging/visualization.py). Loads pre-committed FITS at
+  # full resolution and builds the mask from dataset.shape_native, so both
+  # PYAUTO_FAST_PLOTS and PYAUTO_SMALL_DATASETS must be unset.
+  - pattern: "ellipse/visualization.py"
+    unset: [PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]
   # modeling_visualization_jit tests the JIT-cached visualization path:
   # needs JAX enabled (Part 1 asserts log_likelihood is a jax.Array), the
   # full-resolution mask, a real Nautilus run for Part 2, and savefig active
   # (Part 2 asserts fit.png lands on disk).
   - pattern: "imaging/modeling_visualization_jit"
     unset: [PYAUTO_DISABLE_JAX, PYAUTO_SMALL_DATASETS, PYAUTO_TEST_MODE, PYAUTO_FAST_PLOTS]
+  # interferometer/visualization.py asserts subplot PNG / FITS files land on
+  # disk. Loads pre-committed FITS at full resolution and uses an explicit
+  # (256, 256) shape_native mask — both PYAUTO_FAST_PLOTS and
+  # PYAUTO_SMALL_DATASETS must be unset (the 15x15 cap caps even when
+  # shape_native is explicit).
+  - pattern: "interferometer/visualization.py"
+    unset: [PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]
   # interferometer/visualization_jax exercises the jit-cached
   # fit_for_visualization path on the interferometer side.
   - pattern: "interferometer/visualization_jax"
@@ -63,6 +79,11 @@ overrides:
   # interferometer/modeling_visualization_jit — live Nautilus + JIT path.
   - pattern: "interferometer/modeling_visualization_jit"
     unset: [PYAUTO_DISABLE_JAX, PYAUTO_SMALL_DATASETS, PYAUTO_TEST_MODE, PYAUTO_FAST_PLOTS]
+  # quantity/visualization.py asserts subplot PNG files land on disk and
+  # builds an explicit (30, 30) shape_native mask which would mismatch the
+  # 15x15 cap from PYAUTO_SMALL_DATASETS=1.
+  - pattern: "quantity/visualization.py"
+    unset: [PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]
   # quantity/visualization_jax exercises the jit-cached
   # fit_for_visualization path on the quantity side (wired in
   # PyAutoGalaxy #404).


### PR DESCRIPTION
## Summary
Three visualization scripts (`scripts/ellipse/visualization.py`, `scripts/interferometer/visualization.py`, `scripts/quantity/visualization.py`) had no `env_vars.yaml` override at all, so they ran on the build server with the defaults (`PYAUTO_FAST_PLOTS=1`, `PYAUTO_SMALL_DATASETS=1`). `PYAUTO_FAST_PLOTS=1` short-circuits `subplot_save` / `save_figure` in PyAutoArray (no PNG ever written), so the PNG-existence assertions at the end of each script failed — these three scripts are part of **triage Cluster A**.

This PR adds the missing overrides, mirroring the existing `imaging/visualization.py` entry. All three scripts load pre-committed FITS at full resolution and build explicit `shape_native` masks, so both `PYAUTO_FAST_PLOTS` and `PYAUTO_SMALL_DATASETS` must be unset (the 15×15 `SMALL_DATASETS` cap applies even when `shape_native` is explicit).

Also updates the pattern-convention comment header to document the behaviour after PyAutoBuild #91 lands: patterns containing `/` substring-match against the full path **including extension**, so `.py` can be used as an anchor.

## Configs Changed
- `config/build/env_vars.yaml`:
  - Updated pattern-convention header comment to document `.py`-anchored patterns.
  - Added override for `ellipse/visualization.py` → `unset: [PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]`.
  - Added override for `interferometer/visualization.py` → `unset: [PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]`.
  - Added override for `quantity/visualization.py` → `unset: [PYAUTO_FAST_PLOTS, PYAUTO_SMALL_DATASETS]`.

## Upstream PR
PyAutoBuild #91 — depends on its `_pattern_matches` fix to make the existing `imaging/visualization.py` override fire correctly (was previously dead despite being present). Without #91 the three new overrides ship correctly but the existing `imaging/visualization.py` entry stays dead.

## Test Plan
- [x] End-to-end smoke under autobuild-resolved env (full `build_env_for_script` pipeline, with PyAutoBuild #91 applied): all four `visualization.py` scripts pass — ellipse 50.6s, imaging 95.2s, interferometer 30.9s, quantity 11.8s.
- [ ] `/smoke_test autogalaxy_test` runs cleanly.

Next triage cluster regen should clear the autogalaxy entries of Cluster A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)