### PR TITLE
triage 2026-05-20 cleanup: env_vars override for convolver_mixed_precision

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -28,6 +28,12 @@ overrides:
   # need JAX enabled and full-size datasets, same as jax_likelihood_functions/.
   - pattern: "jax_grad/"
     unset: [PYAUTO_SMALL_DATASETS, PYAUTO_DISABLE_JAX]
+  # convolver_mixed_precision asserts the convolver dispatches mixed-precision
+  # arrays cleanly. It loads a pre-committed 80x80 array; PYAUTO_SMALL_DATASETS=1
+  # would cap the mask to 15x15 and the assertion would fail with a shape mismatch
+  # before the precision check even ran.
+  - pattern: "jax_assertions/convolver_mixed_precision"
+    unset: [PYAUTO_SMALL_DATASETS]
   # Model composition scripts assert exact prior_count for configured gaussian_per_basis.
   # PYAUTO_SMALL_DATASETS=1 reduces total_gaussians and changes prior_count.
   - pattern: "model_composition/"


### PR DESCRIPTION
## Summary
**Cluster C** from the 2026-05-20T18-55-23Z release-prep triage — `scripts/jax_assertions/convolver_mixed_precision.py` failed with `autoarray.exc.ArrayException: Input array_2d shape = (80, 80), Input mask_2d shape_native = (15, 15)`. The script loads a pre-committed 80×80 array; with `PYAUTO_SMALL_DATASETS=1` (the workspace default), the mask is capped to 15×15 and the assertion fails on shape mismatch before the precision check ever runs.

Add a `jax_assertions/convolver_mixed_precision` pattern to `config/build/env_vars.yaml` that unsets `PYAUTO_SMALL_DATASETS`. Per the user's `feedback_env_vars_yaml_overrides` memory: fix smoke env-var conflicts via the workspace's env_vars.yaml, not by mutating `os.environ` in the script.

## API Changes
None — single yaml override addition.
See full details below.

## Test Plan
- [x] Run repro one-liner emitted by `autobuild repro_command` after override added — script reports `convolver_mixed_precision: all assertions passed`.
- [ ] Next `autobuild run_all` no longer lists this script as a failure.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed
- `config/build/env_vars.yaml` — one new per-pattern override for `jax_assertions/convolver_mixed_precision`.

### Migration
None.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)