### PR TITLE
test(viz): __Visualization Sanity__ rollout across visualization_jax*.py

### DIFF
--- a/scripts/imaging/visualization_jax.py
+++ b/scripts/imaging/visualization_jax.py
@@ -131,3 +131,33 @@ VisualizerImaging.visualize(
 )
 assert (image_path / "fit.png").exists(), "fit.png was not produced"
 print("PILOT SUCCEEDED — JAX-backed visualization produced fit.png/galaxies.png.")
+
+
+"""
+__Visualization Sanity__
+
+Phase D.2.a rollout — autogalaxy variant (no Tracer / no lensing
+latents). Asserts `fit.model_data` finite + non-zero and
+`fit.figure_of_merit` finite on the script's prior-median fit, catching
+the analogous failure mode where the JAX path silently produces all-zero
+or NaN model output despite the cosmetic plot looking fine.
+"""
+import numpy as _sanity_np
+
+_fit_for_vis = analysis.fit_from(instance=instance)
+_model_image = _sanity_np.asarray(_fit_for_vis.model_data)
+assert _sanity_np.isfinite(_model_image).all(), (
+    "fit.model_data has nan/inf — JAX-trace mismatch or inversion collapse"
+)
+assert float(_sanity_np.abs(_model_image).sum()) > 0.0, (
+    "fit.model_data all-zero — light profile evaluation collapsed"
+)
+_fom = float(_fit_for_vis.figure_of_merit)
+assert _sanity_np.isfinite(_fom), (
+    f"figure_of_merit = {_fom} — chi² nan/inf, fit collapsed"
+)
+print(
+    f"  PASS Visualization Sanity (autogalaxy imaging): "
+    f"|model_data|.sum() = {float(_sanity_np.abs(_model_image).sum()):.4f}, "
+    f"figure_of_merit = {_fom:.4f}"
+)

--- a/scripts/interferometer/visualization_jax.py
+++ b/scripts/interferometer/visualization_jax.py
@@ -131,3 +131,33 @@ VisualizerInterferometer.visualize(
 )
 assert (image_path / "fit.png").exists(), "fit.png was not produced"
 print("PILOT SUCCEEDED — JAX-backed interferometer visualization produced fit.png.")
+
+
+"""
+__Visualization Sanity__
+
+Phase D.2.a rollout — autogalaxy interferometer variant (no Tracer).
+Asserts `fit.model_data` (complex Visibilities) finite + non-zero and
+`fit.figure_of_merit` finite, catching NUFFT / inversion collapse that
+would leave the cosmetic plot OK but the underlying visibilities
+all-zero / nan.
+"""
+import numpy as _sanity_np
+
+_fit_for_vis = analysis.fit_from(instance=instance)
+_mv = _sanity_np.asarray(_fit_for_vis.model_data)
+assert _sanity_np.isfinite(_mv).all(), (
+    "fit.model_data (visibilities) have nan/inf — NUFFT / inversion collapse"
+)
+assert float(_sanity_np.abs(_mv).sum()) > 0.0, (
+    "fit.model_data (visibilities) all-zero — NUFFT / inversion collapse"
+)
+_fom = float(_fit_for_vis.figure_of_merit)
+assert _sanity_np.isfinite(_fom), (
+    f"figure_of_merit = {_fom} — chi² nan/inf, fit collapsed"
+)
+print(
+    f"  PASS Visualization Sanity (autogalaxy interferometer): "
+    f"|model_data|.sum() = {float(_sanity_np.abs(_mv).sum()):.4f}, "
+    f"figure_of_merit = {_fom:.4f}"
+)

--- a/scripts/quantity/visualization_jax.py
+++ b/scripts/quantity/visualization_jax.py
@@ -122,3 +122,32 @@ VisualizerQuantity.visualize(
 
 assert (image_path / "fit.png").exists(), "fit.png was not produced"
 print("PILOT SUCCEEDED — JAX-backed quantity visualization produced fit.png.")
+
+
+"""
+__Visualization Sanity__
+
+Phase D.2.a rollout — autogalaxy quantity variant (no Tracer, no
+lensing). `FitQuantity.model_data` is the model field on the dataset
+grid; the analogous failure mode is "JAX trace through the quantity
+helpers loses tracer values → model field collapses to zero/NaN".
+"""
+import numpy as _sanity_np
+
+_fit_for_vis = analysis.fit_from(instance=instance)
+_model_field = _sanity_np.asarray(_fit_for_vis.model_data)
+assert _sanity_np.isfinite(_model_field).all(), (
+    "fit.model_data has nan/inf — JAX-trace mismatch on quantity helpers"
+)
+assert float(_sanity_np.abs(_model_field).sum()) > 0.0, (
+    "fit.model_data all-zero — quantity model field collapsed"
+)
+_fom = float(_fit_for_vis.figure_of_merit)
+assert _sanity_np.isfinite(_fom), (
+    f"figure_of_merit = {_fom} — chi² nan/inf, fit collapsed"
+)
+print(
+    f"  PASS Visualization Sanity (autogalaxy quantity): "
+    f"|model_data|.sum() = {float(_sanity_np.abs(_model_field).sum()):.4f}, "
+    f"figure_of_merit = {_fom:.4f}"
+)


### PR DESCRIPTION
## Summary

Phase D.2.a of `z_features/fast_visualization.md` — companion to the autolens_workspace_test PR. Adds `__Visualization Sanity__` blocks to the three existing `visualization_jax*.py` scripts in this repo (non-lensing — no Tracer).

Insertion point: end of script (after the existing `PILOT SUCCEEDED` print). Same non-lensing template as Phase D.1 (PR #54): `fit.model_data` finite + non-zero, `fit.figure_of_merit` finite. Catches the analogous failure mode: JAX-trace mismatch or inversion collapse leaving the cosmetic plot OK but the underlying model output all-zero / NaN.

## Scripts Changed

- `scripts/imaging/visualization_jax.py` — `fit.model_data` (Array2D) + `fit.figure_of_merit` finite/non-zero via `analysis.fit_from(instance=instance)`.
- `scripts/interferometer/visualization_jax.py` — same shape; `fit.model_data` is an `aa.Visibilities` (complex array). `np.abs().sum()` handles both shapes.
- `scripts/quantity/visualization_jax.py` — same shape applied to `FitQuantity`. Confirmed `FitQuantity.model_data` exists on the live API (autogalaxy/quantity/fit_quantity.py:71-72).

## Upstream PR

None — this is a workspace-only test-coverage task.

## Test Plan

- [x] `imaging/visualization_jax.py` — full local run: `|model_data|.sum() = 1862.2458, figure_of_merit = -26675.7406`.
- [x] `interferometer/visualization_jax.py` — full local run: `|model_data|.sum() = 121361.8279, figure_of_merit = -3321.3573`.
- [x] `quantity/visualization_jax.py` — full local run: `|model_data|.sum() = 290.8677, figure_of_merit = 1005.1682`.
- [ ] Workspace smoke tests via `/smoke_test autogalaxy_workspace_test` (smoke list doesn't include `visualization_jax*.py`).

## Out of Scope (Phase D.2.b)

- New `modeling_visualization_jit.py` for `scripts/ellipse/` (only `visualization_jax.py` exists today).
- New `modeling_visualization_jit.py` for `scripts/quantity/` (only `visualization_jax.py` exists today).
- New `visualization_jax.py` for `scripts/ellipse/` (currently missing).

Closes Jammy2211/autolens_workspace_test#114 (alongside the autolens_workspace_test companion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
