### PR TITLE
fix: inject test_mode segment into aggregator result paths

### DIFF
--- a/scripts/aggregator/ellipse.py
+++ b/scripts/aggregator/ellipse.py
@@ -30,14 +30,14 @@ def clean(database_file):
     database_sqlite = path.join(conf.instance.output_path, f"{database_file}.sqlite")
     if path.exists(database_sqlite):
         os.remove(database_sqlite)
-    result_path = path.join(conf.instance.output_path, database_file)
+    result_path = path.join(conf.instance.output_path, "test_mode", database_file)
     if path.exists(result_path):
         shutil.rmtree(result_path)
 
 
 @with_config("general", "output", "samples_to_csv", value=True)
 def aggregator_from(database_file, analysis, model, samples):
-    result_path = path.join(conf.instance.output_path, database_file)
+    result_path = path.join(conf.instance.output_path, "test_mode", database_file)
     clean(database_file)
     search = ag.m.MockSearch(
         samples=samples, result=ag.m.MockResult(model=model, samples=samples)

--- a/scripts/aggregator/fit_imaging.py
+++ b/scripts/aggregator/fit_imaging.py
@@ -39,14 +39,14 @@ def clean():
     database_sqlite = path.join(conf.instance.output_path, f"{database_file}.sqlite")
     if path.exists(database_sqlite):
         os.remove(database_sqlite)
-    result_path = path.join(conf.instance.output_path, database_file)
+    result_path = path.join(conf.instance.output_path, "test_mode", database_file)
     if path.exists(result_path):
         shutil.rmtree(result_path)
 
 
 @with_config("general", "output", "samples_to_csv", value=True)
 def aggregator_from(analysis, model, samples):
-    result_path = path.join(conf.instance.output_path, database_file)
+    result_path = path.join(conf.instance.output_path, "test_mode", database_file)
     clean()
     search = ag.m.MockSearch(
         samples=samples, result=ag.m.MockResult(model=model, samples=samples)
@@ -200,7 +200,7 @@ analysis_oversampled = ag.AnalysisImaging(
 database_sqlite = path.join(conf.instance.output_path, f"{db_file_imaging}.sqlite")
 if path.exists(database_sqlite):
     os.remove(database_sqlite)
-result_path = path.join(conf.instance.output_path, db_file_imaging)
+result_path = path.join(conf.instance.output_path, "test_mode", db_file_imaging)
 if path.exists(result_path):
     shutil.rmtree(result_path)
 
@@ -215,7 +215,7 @@ def _agg_imaging():
     analysis_oversampled.visualize_before_fit(paths=search.paths, model=model)
     db = path.join(conf.instance.output_path, f"{db_file_imaging}.sqlite")
     agg = af.Aggregator.from_database(filename=db)
-    agg.add_directory(directory=path.join(conf.instance.output_path, db_file_imaging))
+    agg.add_directory(directory=path.join(conf.instance.output_path, "test_mode", db_file_imaging))
     return agg
 
 
@@ -231,7 +231,7 @@ for dataset_list in dataset_gen:
 database_sqlite = path.join(conf.instance.output_path, f"{db_file_imaging}.sqlite")
 if path.exists(database_sqlite):
     os.remove(database_sqlite)
-result_path = path.join(conf.instance.output_path, db_file_imaging)
+result_path = path.join(conf.instance.output_path, "test_mode", db_file_imaging)
 if path.exists(result_path):
     shutil.rmtree(result_path)
 

--- a/scripts/aggregator/fit_interferometer.py
+++ b/scripts/aggregator/fit_interferometer.py
@@ -39,14 +39,14 @@ def clean():
     database_sqlite = path.join(conf.instance.output_path, f"{database_file}.sqlite")
     if path.exists(database_sqlite):
         os.remove(database_sqlite)
-    result_path = path.join(conf.instance.output_path, database_file)
+    result_path = path.join(conf.instance.output_path, "test_mode", database_file)
     if path.exists(result_path):
         shutil.rmtree(result_path)
 
 
 @with_config("general", "output", "samples_to_csv", value=True)
 def aggregator_from(analysis, model, samples):
-    result_path = path.join(conf.instance.output_path, database_file)
+    result_path = path.join(conf.instance.output_path, "test_mode", database_file)
     clean()
     search = ag.m.MockSearch(
         samples=samples, result=ag.m.MockResult(model=model, samples=samples)
@@ -193,7 +193,7 @@ analysis_custom = ag.AnalysisInterferometer(
 database_sqlite = path.join(conf.instance.output_path, f"{db_file_inter}.sqlite")
 if path.exists(database_sqlite):
     os.remove(database_sqlite)
-result_path = path.join(conf.instance.output_path, db_file_inter)
+result_path = path.join(conf.instance.output_path, "test_mode", db_file_inter)
 if path.exists(result_path):
     shutil.rmtree(result_path)
 
@@ -208,7 +208,7 @@ def _agg_inter():
     analysis_custom.visualize_before_fit(paths=search.paths, model=model)
     db = path.join(conf.instance.output_path, f"{db_file_inter}.sqlite")
     agg = af.Aggregator.from_database(filename=db)
-    agg.add_directory(directory=path.join(conf.instance.output_path, db_file_inter))
+    agg.add_directory(directory=path.join(conf.instance.output_path, "test_mode", db_file_inter))
     return agg
 
 
@@ -224,7 +224,7 @@ for dataset_list in dataset_gen:
 database_sqlite = path.join(conf.instance.output_path, f"{db_file_inter}.sqlite")
 if path.exists(database_sqlite):
     os.remove(database_sqlite)
-result_path = path.join(conf.instance.output_path, db_file_inter)
+result_path = path.join(conf.instance.output_path, "test_mode", db_file_inter)
 if path.exists(result_path):
     shutil.rmtree(result_path)
 

--- a/scripts/aggregator/galaxies.py
+++ b/scripts/aggregator/galaxies.py
@@ -32,14 +32,14 @@ def clean():
     database_sqlite = path.join(conf.instance.output_path, f"{database_file}.sqlite")
     if path.exists(database_sqlite):
         os.remove(database_sqlite)
-    result_path = path.join(conf.instance.output_path, database_file)
+    result_path = path.join(conf.instance.output_path, "test_mode", database_file)
     if path.exists(result_path):
         shutil.rmtree(result_path)
 
 
 @with_config("general", "output", "samples_to_csv", value=True)
 def aggregator_from(analysis, model, samples):
-    result_path = path.join(conf.instance.output_path, database_file)
+    result_path = path.join(conf.instance.output_path, "test_mode", database_file)
     clean()
     search = ag.m.MockSearch(
         samples=samples, result=ag.m.MockResult(model=model, samples=samples)


### PR DESCRIPTION
## Summary
Migration for [PyAutoFit #1292](https://github.com/PyAutoLabs/PyAutoFit/pull/1292), which makes `PYAUTO_TEST_MODE` namespace AutoFit output paths under `output/test_mode/...`. The aggregator integration tests hardcode `PYAUTO_TEST_MODE=1` inline and reconstruct the result directory by joining `conf.instance.output_path` with the database name — they need the `test_mode/` segment too, otherwise `add_directory` scrapes an empty bare path and the assertions fail.

## Scripts Changed
- `scripts/aggregator/galaxies.py` — added `"test_mode"` to `result_path` composition (2 sites)
- `scripts/aggregator/fit_imaging.py` — added `"test_mode"` to `result_path` and `add_directory(...)` for both `database_file` and `db_file_imaging` (5 sites)
- `scripts/aggregator/fit_interferometer.py` — same pattern for `database_file` and `db_file_inter` (5 sites)
- `scripts/aggregator/ellipse.py` — added `"test_mode"` to `result_path` composition (2 sites)

## Upstream PR
https://github.com/PyAutoLabs/PyAutoFit/pull/1292

## Test Plan
- [x] All 4 scripts pass under `PYAUTO_TEST_MODE=2` with the worktree's modified autofit
- [x] `/smoke_test autogalaxy_workspace_test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)