### PR TITLE
ci(smoke): force-reinstall local PyAutoConf at end of install step

### DIFF
--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -67,6 +67,12 @@ jobs:
         pip install "jax<0.7" "jaxlib<0.7"
         pip install "./PyAutoArray[optional]" "./PyAutoGalaxy[optional]"
         pip install tensorflow-probability==0.25.0
+        # The [optional] re-resolution above can upgrade autoconf to the
+        # stale PyPI release (setuptools_scm reports the local copy as
+        # 1.0.dev0 from the shallow checkout). Pin the local source one
+        # last time so site-packages has skip_latents() and other recent
+        # autoconf APIs available at import time.
+        pip install --force-reinstall --no-deps ./PyAutoConf
     - name: Prepare cache dirs
       run: |
         mkdir -p /tmp/numba_cache /tmp/matplotlib


### PR DESCRIPTION
## Summary

Mirror of autolens_workspace_test#134. Currently green here, but the same setuptools_scm `1.0.dev0` + `[optional]` re-resolution sequence can silently swap `autoconf` to a stale PyPI version any time a smoke script imports a recent autoconf API. Apply the same `pip install --force-reinstall --no-deps ./PyAutoConf` so the two `workspace_test` repos stay in sync.

## Test plan

- [ ] Smoke Tests stay green (current state)
- [ ] No new install failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)